### PR TITLE
fix: begin refactoring lines, fix spectator view

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -56,7 +56,7 @@ function App() {
           <Settings />
         </header>
         <div style={appBody}>
-          <Lines socket={socket} />
+          {/*<Lines socket={socket} />*/}
           <LineInput socket={socket} />
           <Poems socket={socket} />
         </div>

--- a/src/components/LineInput/styles.ts
+++ b/src/components/LineInput/styles.ts
@@ -1,5 +1,14 @@
 import React from "react";
 
+export const lineContainer: React.CSSProperties = {
+    margin: "0.25em 0"
+}
+
+export const lineStyle: React.CSSProperties = {
+    flexGrow: 1,
+    whiteSpace: "pre-line",
+};
+
 export const inputBox: React.CSSProperties = {
     width: "100%",
     display: "flex",
@@ -18,12 +27,12 @@ export const donePoemAccordionTitle: React.CSSProperties = {
     margin: "auto",
 }
 
-export const suggestedInputDiv: React.CSSProperties = {
+export const underlineSuggestionDiv: React.CSSProperties = {
     zIndex: 1,
     whiteSpace: "pre",
     gridRowStart: 1,
     gridColumnStart: 1,
-    padding: "0.2em 0",
+    padding: "0",
     textAlign: "center",
     lineHeight: "150%",
     userSelect: "none",
@@ -53,8 +62,8 @@ export const poemInputStyle: React.CSSProperties = {
     // boxShadow: "0.1em 0.1em 0.5em #bbbbbb",
     boxShadow: "none",
     borderRadius: "0.75em",
-    padding: "0.2em 0",
-    whiteSpace: "nowrap",
+    padding: "0",
+    whiteSpace: "pre",
     width: "100%",
     maxWidth: "60ch",
     overflowX: "hidden",
@@ -93,6 +102,7 @@ export const passButton: React.CSSProperties = {
 export const helpMessageStyle: React.CSSProperties = {
     fontFamily: "sans-serif",
     whiteSpace: "pre-line",
+    height: "1.2em",
 };
 
 export const donePoemButton: React.CSSProperties = {
@@ -106,7 +116,7 @@ export const donePoemAccordionText: React.CSSProperties = {
 
 export const lineInputContainer: React.CSSProperties = {
     marginTop: "2em",
-    width: "80%",
+    width: "100%",
 };
 
 export const mainInputContainer: React.CSSProperties = {

--- a/src/components/Lines/index.tsx
+++ b/src/components/Lines/index.tsx
@@ -9,7 +9,6 @@ import {
 } from "../../types";
 import {
   lineStyle,
-  fakeHelpMessage,
 } from "./styles";
 
 // if activeEditor or inactiveEditor, NOTHING is visible here until the end
@@ -25,7 +24,6 @@ function Lines({
   const [lines, setLines] = useState<ILines>({});
 
   const [linesVisible, setLinesVisible] = useState(false);
-  const [helpMessage, setHelpMessage] = useState("");
 
   useEffect(() => {
     // Event handlers for the line and the deleteLine events are set up for the Socket.IO connection.
@@ -39,19 +37,15 @@ function Lines({
 
     const clearLineListener = () => {
       setLines({});
-      console.log("clearLines was reached once");
     };
 
     const userInfoListener = (userInfo: IUserInfo) => {
       if (userInfo["role"] === "activeEditor") {
         setLinesVisible(false);
-        setHelpMessage("");
       } else if (userInfo["role"] === "inactiveEditor") {
         setLinesVisible(false);
-        setHelpMessage("");
       } else if (userInfo["role"] === "spectator") {
         setLinesVisible(true);
-        setHelpMessage("Your friends are writing 👇");
       }
     };
 
@@ -78,12 +72,6 @@ function Lines({
     // The component then displays all lines sorted by the timestamp at which they were created.
     // we can switch this so that it renders previous lines according to a view
     <div className="lines-outer-container">
-      <div
-        className={"fake-help-message"}
-        style={fakeHelpMessage}
-      >
-        {helpMessage}
-      </div>
       <div className="lines-container">
         {[...Object.values(lines)]
           .sort((a, b) => Number(a.time) - Number(b.time))

--- a/src/components/Lines/styles.ts
+++ b/src/components/Lines/styles.ts
@@ -5,6 +5,3 @@ export const lineStyle: React.CSSProperties = {
   whiteSpace: "pre-line",
 };
 
-export const fakeHelpMessage: React.CSSProperties = {
-  fontFamily: "sans-serif",
-};


### PR DESCRIPTION
Prior to this, the spectator view was bugged. Having Lines and LineInput in separated React components meant that the spectator would see the already-submitted lines (in Lines) above several elements at the top of LineInput. This encouraged bad patterns such as trying to hide elements and then replace them with a different element that was trying to imitate the hidden one. But really this was because the HTML elements were in the wrong order. I fixed this, which unfortunately required me to combine Lines into LineInput so that the HTML elements could be in the right order. But this begins the necessary process of refactoring React components into nice modular pieces.