### PR TITLE
chore: cleanup imports, remove eslint disable

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -2,20 +2,13 @@
 
 // CORS stands for Cross-Origin Resource Sharing
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const cors = require("cors");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 export const express = require("express");      // the app framework library
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require("path");                   // for joining paths
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const cookieParser = require("cookie-parser");  // for parsing cookies
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const logger = require("morgan");               // for logging
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const indexRouter = require("./routes/index");  // an express object that routes users to the root page /
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const usersRouter = require("./routes/users");  // an express object that routes users to the page /users
 
 const app = express();                          // instantiate the app object

--- a/server/entity/poem.ts
+++ b/server/entity/poem.ts
@@ -1,4 +1,8 @@
-import { DataTypes, Sequelize } from "sequelize";
+import {
+    DataTypes,
+    Sequelize,
+} from "sequelize";
+
 const isProduction = process.env.NODE_ENV === "production";
 const connectionString = `postgres://${process.env.PG_USER}:${process.env.PG_PASSWORD}@${process.env.PG_HOST}:${process.env.PG_PORT}/${process.env.PG_DATABASE}`;
 

--- a/server/socketFunctionality.ts
+++ b/server/socketFunctionality.ts
@@ -7,6 +7,7 @@ import {
     Server,
     Socket,
 } from "socket.io";
+import { v4 as uuidv4 } from "uuid"; // a function that generates a random uuid for lines
 
 import {
     ClientToServerEvents,
@@ -18,8 +19,10 @@ import {
     ServerToClientEvents,
     SocketData,
 } from "../src/types";
-import { returnPoems, storePoem } from "./queries";
-import { v4 as uuidv4 } from "uuid"; // a function that generates a random uuid for lines
+import {
+    returnPoems,
+    storePoem,
+} from "./queries";
 
 const retrieveNPoemsAtStart = 1;
 const maxEditors = 4;

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -8,6 +8,7 @@ import {
     io,
     Socket,
 } from "socket.io-client";
+import { v4 as uuidv4 } from "uuid";
 
 import GameState from "../GameState";
 import Tutorial from "../Tutorial";
@@ -24,8 +25,6 @@ import type {
     ClientToServerEvents,
     ServerToClientEvents,
 } from "../../types";
-
-import { v4 as uuidv4 } from "uuid";
 
 const isDevelopment = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 const serverPath: URL["pathname"] | URL["href"] = isDevelopment


### PR DESCRIPTION
Fixing up a few things I noticed from your last commit on the previous MR, and removing `eslint-disable` from `app.ts` since we don't have strict on (it lets you commit even with eslint errors), so it's not hurting anything. It would be nice to eventually convert those to imports instead of requires down the road, and that will help to remind us.