### PR TITLE
fix: ensure behavior OK after close tab and use hotkey

### DIFF
--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -220,7 +220,7 @@ class Member {
     }
 
     disconnecting() {
-        console.log("socket disconnecting from", this.socket.rooms);
+        console.log("socket", this.socket.id, " disconnecting from", this.socket.rooms);
     }
 
     sendPoem(poem: IPoem) {
@@ -370,7 +370,7 @@ class Editor extends Member {
         if (thisPoem) {
             const weThinkCurrentLength = thisPoem.lines.length;
             console.log("we think the poem has ", weThinkCurrentLength, "of", thisPoem.targetLines - 2);
-            return weThinkCurrentLength === (thisPoem.targetLines - 2);
+            return weThinkCurrentLength >= (thisPoem.targetLines - 2);
         } else {
             return false;
         }
@@ -580,15 +580,14 @@ function sockets(io: Server<ClientToServerEvents, ServerToClientEvents, InterSer
                 } else {
                     targetView = "/";
                 }
-                const oldSocket = theMember.socket;
-                const oldRooms = theMember.socket.rooms;
-                io.to(oldSocket.id).emit("navigate", "/disconnected"); // send to disconnect page
-                oldRooms.delete(oldRooms.values().next().value); // delete first element (old socket id)
-                oldSocket.disconnect(); // force disconnect
-                socket.join(Array.from(oldRooms)); // re-join the same rooms
-                theMember.socket = socket; // connect the new socket in preference of the old
-                theMember.setReceive(); // re-establish server-side listeners
-                io.to(socket.id).emit("navigate", targetView); // force navigate
+                // if the socket is still connected, send them to disconnected view
+                io.to(theMember.socket.id).emit("navigate", "/disconnected");
+                theMember.socket.disconnect(); // force disconnect
+                delete theMember.socket;
+                theMember.socket = socket; // connect the new socket
+                theMember.joinRoom();    // re-join the correct rooms
+                // theMember.setReceive(); // amazingly, this isn't necessary...
+                io.to(socket.id).emit("navigate", targetView); // navigate to correct view
             } // else this device isn't in a room yet, nothing to do
 
             socketIDToDeviceID[socket.id] = deviceID; // since socket is always uuid, won't overwrite

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -357,7 +357,11 @@ const LineInput = () => {
     // might not be necessary, but it's kind of nice
     // note we use passEnabledRef instead of passEnabled because it gets the current value
         if (passEnabledRef.current && (ctrlKey || metaKey) && (key === "Enter" || charCode === 13)) {
-            passTurn();
+            if (onLastLine) {
+                completePoem();
+            } else {
+                passTurn();
+            }
         }
     }
 


### PR DESCRIPTION
Prior to this, if you closed the tab and tried to reconnect the game, the behavior wasn't correct. Now, if you close the tab and then reconnect in a new tab, you will be connected to the same ongoing game. This is the same as if you opened in a new tab without closing the old, except that in the latter case it also navigates the old tab to a "disconnected" page and forcibly disconnects that socket.

Also, I noticed that if you use the hotkey to submit lines (ctrl + enter or cmd + enter), it would sidestep the possibility that the poem was supposed to be completed. Was an easy fix.