### PR TITLE
feat: basic leave game functionality

### DIFF
--- a/server/entity/poem.ts
+++ b/server/entity/poem.ts
@@ -14,8 +14,8 @@ export const pgSequelConn = new Sequelize(
         ? {
             dialectOptions: {
                 ssl: {
-                    require: true,
                     rejectUnauthorized: false,
+                    require: true,
                 },
             },
         }
@@ -26,13 +26,13 @@ export const Poem = pgSequelConn.define(
     "Poem",
     {
         // Model attributes are defined here
-        title: {
-            type: DataTypes.TEXT,
-            allowNull: false,
-        },
         content: {
-            type: DataTypes.TEXT,
             allowNull: false,
+            type: DataTypes.TEXT,
+        },
+        title: {
+            allowNull: false,
+            type: DataTypes.TEXT,
         },
     },
     {

--- a/server/queries.ts
+++ b/server/queries.ts
@@ -39,7 +39,7 @@ async function returnPoems(nPoems: number) {
 
 async function storePoem({ title, content }: IPoem) {
     try {
-        await Poem.create({ title, content });
+        await Poem.create({ content, title });
     } catch ({ stack }) {
         console.log(stack);
     }

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -28,8 +28,8 @@ const retrieveNPoemsAtStart = 1;
 const maxEditors = 4;
 const defaultGameSettings: IGameSettingsInfo = {
     lineLength: LineLength.short,
-    nRounds: 2,
     nPoems: 1,
+    nRounds: 2,
 };
 
 
@@ -38,17 +38,17 @@ async function populatePoems() {
     const dbPoems = await returnPoems(retrieveNPoemsAtStart) as Array<IPoem>;
     for (const { id, createdAt, title, content } of dbPoems) {
         poems.add({
-            id,
-            createdAt,
-            title,
             content,
+            createdAt,
+            id,
+            title,
         });
     }
 }
 populatePoems();
 
 // New global data structures
-const socketIDToDeviceID: IObjectStringToString = {};  // unique on socket. can have multiple devices on socket
+const socketIDToDeviceID: IObjectStringToString = {};
 const deviceIDToSocketID: IObjectStringToString = {};  // unique on device. only latest is present
 const deviceIDToRoomID: IObjectStringToString = {};
 const roomIDToRoom: Map<string, any> = new Map();
@@ -62,8 +62,8 @@ class Room {
 
     editors: Map<string, Editor>;
     spectators: Map<string, Spectator>;
-    editorNames: Array<string>;
-    spectatorNames: Array<string>;
+    // editorNames: Array<string>;
+    // spectatorNames: Array<string>;
     gameSettings: IGameSettingsInfo;
     gameOngoing: boolean;
     nPoemsInRotation: number;
@@ -79,8 +79,8 @@ class Room {
 
         this.editors = new Map();    // deviceID to editorObj
         this.spectators = new Map(); // deviceID to spectatorObj
-        this.editorNames = [];       // deviceID to editorObj
-        this.spectatorNames = [];    // deviceID to spectatorObj
+        // this.editorNames = [];       // deviceID to editorObj
+        // this.spectatorNames = [];    // deviceID to spectatorObj
         this.gameSettings = defaultGameSettings;
         this.gameOngoing = false;
         this.nPoemsInRotation = 0;
@@ -88,20 +88,38 @@ class Room {
 
     addEditor(deviceUUID: string, editorObj: Editor) {
         this.editors.set(deviceUUID, editorObj);
-        this.editorNames.push(editorObj.name);
+        // this.editorNames.push(editorObj.name);
+        this.sendCurrentUserTableInfo(); // give the room updated user info
+    }
+
+    removeEditor(deviceUUID: string) {
+        this.editors.delete(deviceUUID);
         this.sendCurrentUserTableInfo(); // give the room updated user info
     }
 
     addSpectator(deviceUUID: string, spectatorObj: Spectator) {
         this.spectators.set(deviceUUID, spectatorObj);
-        this.spectatorNames.push(spectatorObj.name);
+        // this.spectatorNames.push(spectatorObj.name);
+        this.sendCurrentUserTableInfo(); // give the room updated user info
+    }
+
+    removeSpectator(deviceUUID: string) {
+        this.spectators.delete(deviceUUID);
         this.sendCurrentUserTableInfo(); // give the room updated user info
     }
 
     currentUserTableInfo() {
+        const editorNameArr: Array<string> = [];
+        const spectatorNameArr: Array<string> = [];
+        for (const thisEditor of this.editors.values()) {
+            editorNameArr.push(thisEditor.name);
+        }
+        for (const thisSpectator of this.spectators.values()) {
+            spectatorNameArr.push(thisSpectator.name);
+        }
         return {
-            editors: this.editorNames,
-            spectators: this.spectatorNames,
+            editors: editorNameArr,
+            spectators: spectatorNameArr,
         };
     }
 
@@ -133,6 +151,12 @@ class Room {
         this.gameOngoing = true;
     }
 
+    reorganizeEditors() {
+        for (const thisEditor of this.editors.values()) {
+            thisEditor.prepareForGame();
+        }
+    }
+
 }
 
 class Member {
@@ -149,13 +173,13 @@ class Member {
 
     constructor(
         io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
-        hostSocket: Socket,
+        socket: Socket,
         roomID: string,
         deviceID: string,
         name: string,
     ) {
         this.io = io;
-        this.socket = hostSocket;
+        this.socket = socket;
         this.roomID = roomID;
         this.deviceID = deviceID;
         this.name = name;
@@ -164,6 +188,14 @@ class Member {
     joinRoom() {
         this.socket.join(this.roomID);
         this.setReceive(); // listen for certain messages from client
+    }
+
+    leaveRoom() {
+        console.log(this.name, " leaving ", this. roomID);
+        this.io.to(this.socket.id).emit("navigate", "/"); // navigate home (if possible)
+        delete deviceIDToRoomID[this.deviceID];
+        this.socket.leave(this.roomID);
+        this.unsetReceive(); // remove listeners
     }
 
     // setSend
@@ -180,10 +212,23 @@ class Member {
         this.socket.on("getGameSettingsInfo", () => this.requestGameSettingsInfo());
         this.socket.on("getSettingsEnabled", () => this.requestSettingsEnabled());
         this.socket.on("getPoems", () => this.getPoems()); // initial load
+        this.socket.on("leave", () => this.leaveRoom());
 
         // These are all reserved events
         this.socket.on("disconnect", () => this.disconnect());
         this.socket.on("disconnecting", () => this.disconnecting());
+    }
+
+    unsetReceive() {
+        this.socket.off("getUserTableInfo", () => this.requestUserTableInfo());
+        this.socket.off("getGameSettingsInfo", () => this.requestGameSettingsInfo());
+        this.socket.off("getSettingsEnabled", () => this.requestSettingsEnabled());
+        this.socket.off("getPoems", () => this.getPoems()); // initial load
+        this.socket.off("leave", () => this.leaveRoom());
+
+        // These are all reserved events
+        this.socket.off("disconnect", () => this.disconnect());
+        this.socket.off("disconnecting", () => this.disconnecting());
     }
 
     requestUserTableInfo() {
@@ -204,6 +249,10 @@ class Member {
     }
 
     disconnect() {
+        // note this could be called by something as simple as closing the tab
+        // therefore we don't want to boot someone from the game based on this
+        // however if they are AFK, etc, we should do those things
+
         console.log(this.socket.id, "disconnected");
 
         // socketIDToDeviceID
@@ -258,6 +307,13 @@ class Spectator extends Member {
         this.socket.join(this.roomID + "_Spectators");
     }
 
+    leaveRoom() {
+        super.leaveRoom();
+        this.socket.leave(this.roomID + "_Spectators");
+        const thisRoom = roomIDToRoom.get(this.roomID);
+        thisRoom.removeSpectator(this.deviceID);
+    }
+
     setReceive() {
         super.setReceive();
         this.socket.on("getLines", () => this.getAllPoemLines());
@@ -308,6 +364,23 @@ class Editor extends Member {
     joinRoom() {
         super.joinRoom();
         this.socket.join(this.roomID + "_Editors");
+    }
+
+    leaveRoom() {
+        super.leaveRoom();
+        this.socket.leave(this.roomID + "_Editors");
+        const thisRoom = roomIDToRoom.get(this.roomID);
+        thisRoom.removeEditor(this.deviceID);
+
+        // hand off any poems in your queue to the next person
+        const nextEditor = thisRoom.editors.get(this.targetEditorID);
+        nextEditor.poemQueue.push(...this.poemQueue);
+        if (!nextEditor.isCurrentlyEditing) {
+            nextEditor.possibleStartNewTurn();
+        }
+
+        // trigger the room to reorganize the editors
+        thisRoom.reorganizeEditors();
     }
 
     // setSend
@@ -456,9 +529,9 @@ class Editor extends Member {
     handlePoem(poemString: string) {
 
         const poem: IPoem = {
-            id: uuidv4(),
             content: poemString,
             createdAt: new Date(),
+            id: uuidv4(),
             title: `exquisite text #${Math.round(Math.random() * 100)}`,
         };
         poems.add(poem);
@@ -475,6 +548,20 @@ class VIPEditor extends Editor {
     joinRoom() {
         super.joinRoom();
         this.socket.join(this.roomID + "_VIP");
+    }
+
+    leaveRoom() {
+        // super.leaveRoom();
+        // this.socket.leave(this.roomID + "_VIP");
+        //
+        // // should make the next editor in line become VIP...
+        // const thisRoom = roomIDToRoom.get(this.roomID);
+        // const nextEditor = thisRoom.editors.get(this.targetEditorID);
+        // nextEditor.becomeVIP();  // or something
+
+        // TODO: implement VIP leaves the room
+        // only tricky if we are still in the lobby...
+        console.log("Having the VIP leave the room is not implemented yet.");
     }
 
     setReceive() {

--- a/server/start.ts
+++ b/server/start.ts
@@ -57,8 +57,8 @@ const httpServer = createServer(app);
 
 const io = new Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>(httpServer, {
     cors: {
-        origin: "*",
         methods: [ "GET", "POST" ],
+        origin: "*",
     },
 });
 

--- a/src/components/GameSnack/index.tsx
+++ b/src/components/GameSnack/index.tsx
@@ -48,7 +48,7 @@ const GameSnack = () => {
 
     return (
         <Snackbar
-            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            anchorOrigin={{ horizontal: "center", vertical: "bottom" }}
             open={snackOpen}
             onClose={handleClose}
             message={snackMessage}

--- a/src/components/GameSnack/index.tsx
+++ b/src/components/GameSnack/index.tsx
@@ -48,7 +48,10 @@ const GameSnack = () => {
 
     return (
         <Snackbar
-            anchorOrigin={{ horizontal: "center", vertical: "bottom" }}
+            anchorOrigin={{
+                horizontal: "center",
+                vertical: "bottom",
+            }}
             open={snackOpen}
             onClose={handleClose}
             message={snackMessage}

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -25,8 +25,8 @@ function Leave() {
         <div className={"leave-game-accordion"} style={{ marginTop: "1em" }}>
             <Accordion>
                 <AccordionSummary
-                    expandIcon={<ExpandMoreIcon />}
                     aria-controls="panel1a-content"
+                    expandIcon={<ExpandMoreIcon />}
                     id="panel1a-header"
                 >
                     <div

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -1,0 +1,60 @@
+import Button from "@mui/material/Button";
+import * as React from "react";
+
+import { useSocket } from "../App";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { accordionText, accordionTitle, accordionButton } from "../LineInput/styles";
+import Typography from "@mui/material/Typography";
+import AccordionDetails from "@mui/material/AccordionDetails";
+
+function Leave() {
+    const { socket } = useSocket();
+
+    const handleLeaveButton = () => {
+        socket.emit("leave");
+    };
+
+    return (
+        <div className={"leave-game-accordion"} style={{ marginTop: "1em" }}>
+            <Accordion>
+                <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls="panel1a-content"
+                    id="panel1a-header"
+                >
+                    <div
+                        className={"leave-game-accordion-title"}
+                        style={accordionTitle}
+                    >
+                        <Typography>
+                            <strong>Need to leave the game early?</strong>
+                        </Typography>
+                    </div>
+                </AccordionSummary>
+                <AccordionDetails>
+                    <div
+                        className={"leave-game-accordion-text"}
+                        style={accordionText}
+                    >
+                        Only press this button if you are absolutely certain you want to leave!
+                    </div>
+                    <div
+                        className={"leave-game-button"}
+                        style={accordionButton}
+                    >
+                        <Button
+                            onClick={handleLeaveButton}
+                            variant="contained"
+                        >
+                            Leave Game
+                        </Button>
+                    </div>
+                </AccordionDetails>
+            </Accordion>
+        </div>
+    );
+}
+
+export default Leave;

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -1,13 +1,18 @@
-import Button from "@mui/material/Button";
 import * as React from "react";
-
-import { useSocket } from "../App";
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
+import Button from "@mui/material/Button";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { accordionText, accordionTitle, accordionButton } from "../LineInput/styles";
+
 import Typography from "@mui/material/Typography";
 import AccordionDetails from "@mui/material/AccordionDetails";
+
+import { useSocket } from "../App";
+import {
+    accordionButton,
+    accordionText,
+    accordionTitle,
+} from "../LineInput/styles";
 
 function Leave() {
     const { socket } = useSocket();

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -13,9 +13,9 @@ import "./LineInput.css";
 import {
     activeInput,
     caret,
-    donePoemAccordionText,
-    donePoemAccordionTitle,
-    donePoemButton,
+    accordionText,
+    accordionTitle,
+    accordionButton,
     errorMessage,
     helpMessageStyle,
     inactiveInput,
@@ -499,7 +499,7 @@ const LineInput = () => {
                             >
                                 <div
                                     className={"done-poem-accordion-title"}
-                                    style={donePoemAccordionTitle}
+                                    style={accordionTitle}
                                 >
                                     <Typography>
                                         <strong>Does the poem seem like it is done?</strong>
@@ -509,14 +509,14 @@ const LineInput = () => {
                             <AccordionDetails>
                                 <div
                                     className={"done-poem-accordion-text"}
-                                    style={donePoemAccordionText}
+                                    style={accordionText}
                                 >
                   Only press this button if you are absolutely certain the poem
                   is done!
                                 </div>
                                 <div
                                     className={"done-poem-button"}
-                                    style={donePoemButton}
+                                    style={accordionButton}
                                 >
                                     <Button
                                         variant={"contained"}

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -13,9 +13,6 @@ import "./LineInput.css";
 import {
     activeInput,
     caret,
-    accordionText,
-    accordionTitle,
-    accordionButton,
     errorMessage,
     helpMessageStyle,
     inactiveInput,

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -11,6 +11,9 @@ import * as React from "react";
 import { useSocket } from "../App";
 import "./LineInput.css";
 import {
+    accordionButton,
+    accordionText,
+    accordionTitle,
     activeInput,
     caret,
     errorMessage,

--- a/src/components/LineInput/styles.ts
+++ b/src/components/LineInput/styles.ts
@@ -15,7 +15,7 @@ export const activeInput: React.CSSProperties = {
     width: "100%",
 };
 
-export const donePoemAccordionTitle: React.CSSProperties = {
+export const accordionTitle: React.CSSProperties = {
     margin: "auto",
 };
 
@@ -97,11 +97,11 @@ export const helpMessageStyle: React.CSSProperties = {
     whiteSpace: "pre-line",
 };
 
-export const donePoemButton: React.CSSProperties = {
+export const accordionButton: React.CSSProperties = {
     textAlign: "center",
 };
 
-export const donePoemAccordionText: React.CSSProperties = {
+export const accordionText: React.CSSProperties = {
     fontFamily: "sans-serif",
     marginBottom: "1em",
 };

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,15 +1,60 @@
+import * as React from "react";
+import Popover from "@mui/material/Popover";
 import SettingsIcon from "@mui/icons-material/Settings";
 import IconButton from "@mui/material/IconButton";
-import * as React from "react";
+// import Leave from "../Leave";
+// import { useSocket } from "../App";
+// import Button from "@mui/material/Button";
 
-const Settings = () => {
+function Settings() {
+    const [ anchorEl, setAnchorEl ] = React.useState<Element | null>(null);
+    const handleClick = (event: { currentTarget: React.SetStateAction<Element | null> }) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+    const isOpen = Boolean(anchorEl);
+    const id = isOpen
+        ? "simple-popover"
+        : undefined;
+
+    // const { socket } = useSocket();
+    //
+    // const handleLeaveButton = () => {
+    //     socket.emit("leave");
+    // };
+
     return (
         <div className={"settings"}>
-            <IconButton aria-label="settings" size={"large"}>
+            <IconButton
+                aria-label="settings"
+                onClick={handleClick}
+                size={"large"}
+            >
                 <SettingsIcon />
             </IconButton>
+            <Popover
+                id={id}
+                open={isOpen}
+                anchorEl={anchorEl}
+                onClose={handleClose}
+                anchorOrigin={{
+                    horizontal: "left",
+                    vertical: "bottom",
+                }}
+            >
+                {/*<Leave />*/}
+                {/*<Button*/}
+                {/*    onClick={handleLeaveButton}*/}
+                {/*    variant="contained"*/}
+                {/*>*/}
+                {/*    Leave Game*/}
+                {/*</Button>*/}
+                Nothing yet :)
+            </Popover>
         </div>
     );
-};
+}
 
 export default Settings;

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -35,14 +35,14 @@ function Settings() {
                 <SettingsIcon />
             </IconButton>
             <Popover
-                id={id}
-                open={isOpen}
                 anchorEl={anchorEl}
-                onClose={handleClose}
                 anchorOrigin={{
                     horizontal: "left",
                     vertical: "bottom",
                 }}
+                id={id}
+                onClose={handleClose}
+                open={isOpen}
             >
                 {/*<Leave />*/}
                 {/*<Button*/}

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
+import IconButton from "@mui/material/IconButton";
 import Popover from "@mui/material/Popover";
 import SettingsIcon from "@mui/icons-material/Settings";
-import IconButton from "@mui/material/IconButton";
 // import Leave from "../Leave";
 // import { useSocket } from "../App";
 // import Button from "@mui/material/Button";

--- a/src/screens/Game/index.tsx
+++ b/src/screens/Game/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import GameTransition from "../../components/GameTransition";
+import Leave from "../../components/Leave";
 import LineInput from "../../components/LineInput";
 import Poems from "../../components/Poems";
 import { appBody } from "./styles";
@@ -9,6 +10,7 @@ function Game() {
     return (
         <div style={appBody}>
             <LineInput />
+            <Leave />
             <Poems />
             <GameTransition />
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,7 @@ export interface ClientToServerEvents {
     getEditorActive: () => void;
     passTurn: (a: string, b: string) => void;
     lastLine: (a: string) => void;
+    leave: () => void;
 }
 
 export interface InterServerEvents {


### PR DESCRIPTION
This sketches up the basic functionality for game members to leave the game, focused on allowing Editors to cleanly leave the game. Editors see a new accordion menu that shows a button that allows them to leave (it's hidden so they don't accidentally do it).

Since leaving the game is kind of meaningless for the Host, that's not implemented in any way. And since Spectators leaving has no real effect except to remove their name from the Lobby view, I didn't implement that either.

When a member leaves the game, it navigates them to the root view, deletes the device from the device table, leaves the socket room, turns off the listeners.

When an editor leaves the game, it also removes them from the room carefully, handing off any poems in queue to the next editor, and reorganizes the editors in the room.

Also I had to fix a few things to please ESLint given the new rules about alphabetizing.