### PR TITLE
feat: "done" and "leave" are FABs with confirm popovers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,8 +53,5 @@ module.exports = {
             "error",
             "always",
         ],
-        "sort-keys": [
-            "error",
-        ],
     },
 };

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -319,6 +319,11 @@ class Spectator extends Member {
         this.socket.on("getLines", () => this.getAllPoemLines());
     }
 
+    unsetReceive() {
+        super.unsetReceive();
+        this.socket.off("getLines", () => this.getAllPoemLines());
+    }
+
     getAllPoemLines() {
         const thisRoom = roomIDToRoom.get(this.roomID);
         for (const thisEditor of thisRoom.editors.values()) {
@@ -373,10 +378,12 @@ class Editor extends Member {
         thisRoom.removeEditor(this.deviceID);
 
         // hand off any poems in your queue to the next person
-        const nextEditor = thisRoom.editors.get(this.targetEditorID);
-        nextEditor.poemQueue.push(...this.poemQueue);
-        if (!nextEditor.isCurrentlyEditing) {
-            nextEditor.possibleStartNewTurn();
+        if (thisRoom.gameOngoing) {
+            const nextEditor = thisRoom.editors.get(this.targetEditorID);
+            nextEditor.poemQueue.push(...this.poemQueue);
+            if (!nextEditor.isCurrentlyEditing) {
+                nextEditor.possibleStartNewTurn();
+            }
         }
 
         // trigger the room to reorganize the editors
@@ -395,6 +402,16 @@ class Editor extends Member {
         this.socket.on("passTurn", (firstPart, secondPart) => this.handlePassTurn(firstPart, secondPart));
         this.socket.on("lastLine", (value) => this.handleLastLine(value)); // whenever a new line has been submitted into the poem.
         this.socket.on("getLastLineStatus", () => this.requestLastLineStatus());
+    }
+
+    unsetReceive() {
+        super.unsetReceive();
+        this.socket.off("getLineEdit", () => this.requestLineEdit()); // initial populate
+        this.socket.off("lineEdit", (value) => this.handleLineEdit(value));  //whenever the input box is edited.
+        this.socket.off("getEditorActive", () => this.requestActivity());
+        this.socket.off("passTurn", (firstPart, secondPart) => this.handlePassTurn(firstPart, secondPart));
+        this.socket.off("lastLine", (value) => this.handleLastLine(value)); // whenever a new line has been submitted into the poem.
+        this.socket.off("getLastLineStatus", () => this.requestLastLineStatus());
     }
 
     requestLineEdit() {
@@ -568,6 +585,12 @@ class VIPEditor extends Editor {
         super.setReceive();
         this.socket.on("alterGameSettings", (value) => this.alterGameSettings(value));
         this.socket.on("startGame", () => this.broadcastStartGame());
+    }
+
+    unsetReceive() {
+        super.unsetReceive();
+        this.socket.off("alterGameSettings", (value) => this.alterGameSettings(value));
+        this.socket.off("startGame", () => this.broadcastStartGame());
     }
 
     alterGameSettings(gameSettings: IGameSettingsInfo) {

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -315,26 +315,17 @@ class Spectator extends Member {
     setReceive() {
         super.setReceive();
         this.socket.on("getLines", () => this.getAllPoemLines());
-        // this.socket.on("clearLines", () => this.clearLines());
     }
 
     unsetReceive() {
-        console.log("spectator unset reached for", this.name);
         super.unsetReceive();
         this.socket.removeAllListeners("getLines");
-        // this.socket.removeAllListeners("clearLines", () => this.clearLines());
-    }
-
-    clearLines() {
-        this.io.to(this.socket.id).emit("clearLines");
     }
 
     getAllPoemLines() {
         const thisRoom = roomIDToRoom.get(this.roomID);
         for (const thisEditor of thisRoom.editors.values()) {
-            console.log("sending", thisEditor.name);
             for (const thisPoem of thisEditor.poemQueue) {
-                console.log("sending", thisEditor.name, "poem", thisPoem.poemID);
                 thisPoem.sendAllLinesTo(this.socket.id);
             }
         }
@@ -463,7 +454,6 @@ class Editor extends Member {
 
     currentlyOnLastLine() {
         const thisPoem = this.poemQueue[0];
-        console.log(this.name, "currentlyOnLastLine");
         if (thisPoem) {
             const weThinkCurrentLength = thisPoem.lines.length;
             console.log("we think the poem has ", weThinkCurrentLength, "of", thisPoem.targetLines - 2);

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -220,15 +220,13 @@ class Member {
     }
 
     unsetReceive() {
-        this.socket.off("getUserTableInfo", () => this.requestUserTableInfo());
-        this.socket.off("getGameSettingsInfo", () => this.requestGameSettingsInfo());
-        this.socket.off("getSettingsEnabled", () => this.requestSettingsEnabled());
-        this.socket.off("getPoems", () => this.getPoems()); // initial load
-        this.socket.off("leave", () => this.leaveRoom());
-
-        // These are all reserved events
-        this.socket.off("disconnect", () => this.disconnect());
-        this.socket.off("disconnecting", () => this.disconnecting());
+        this.socket.removeAllListeners("getUserTableInfo");
+        this.socket.removeAllListeners("getGameSettingsInfo");
+        this.socket.removeAllListeners("getSettingsEnabled");
+        this.socket.removeAllListeners("getPoems");
+        this.socket.removeAllListeners("leave");
+        this.socket.removeAllListeners("disconnect");
+        this.socket.removeAllListeners("disconnecting");
     }
 
     requestUserTableInfo() {
@@ -317,17 +315,26 @@ class Spectator extends Member {
     setReceive() {
         super.setReceive();
         this.socket.on("getLines", () => this.getAllPoemLines());
+        // this.socket.on("clearLines", () => this.clearLines());
     }
 
     unsetReceive() {
+        console.log("spectator unset reached for", this.name);
         super.unsetReceive();
-        this.socket.off("getLines", () => this.getAllPoemLines());
+        this.socket.removeAllListeners("getLines");
+        // this.socket.removeAllListeners("clearLines", () => this.clearLines());
+    }
+
+    clearLines() {
+        this.io.to(this.socket.id).emit("clearLines");
     }
 
     getAllPoemLines() {
         const thisRoom = roomIDToRoom.get(this.roomID);
         for (const thisEditor of thisRoom.editors.values()) {
+            console.log("sending", thisEditor.name);
             for (const thisPoem of thisEditor.poemQueue) {
+                console.log("sending", thisEditor.name, "poem", thisPoem.poemID);
                 thisPoem.sendAllLinesTo(this.socket.id);
             }
         }
@@ -406,12 +413,12 @@ class Editor extends Member {
 
     unsetReceive() {
         super.unsetReceive();
-        this.socket.off("getLineEdit", () => this.requestLineEdit()); // initial populate
-        this.socket.off("lineEdit", (value) => this.handleLineEdit(value));  //whenever the input box is edited.
-        this.socket.off("getEditorActive", () => this.requestActivity());
-        this.socket.off("passTurn", (firstPart, secondPart) => this.handlePassTurn(firstPart, secondPart));
-        this.socket.off("lastLine", (value) => this.handleLastLine(value)); // whenever a new line has been submitted into the poem.
-        this.socket.off("getLastLineStatus", () => this.requestLastLineStatus());
+        this.socket.removeAllListeners("getLineEdit");
+        this.socket.removeAllListeners("lineEdit");
+        this.socket.removeAllListeners("getEditorActive");
+        this.socket.removeAllListeners("passTurn");
+        this.socket.removeAllListeners("lastLine");
+        this.socket.removeAllListeners("getLastLineStatus");
     }
 
     requestLineEdit() {
@@ -589,8 +596,8 @@ class VIPEditor extends Editor {
 
     unsetReceive() {
         super.unsetReceive();
-        this.socket.off("alterGameSettings", (value) => this.alterGameSettings(value));
-        this.socket.off("startGame", () => this.broadcastStartGame());
+        this.socket.removeAllListeners("alterGameSettings");
+        this.socket.removeAllListeners("startGame");
     }
 
     alterGameSettings(gameSettings: IGameSettingsInfo) {

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -72,7 +72,7 @@ export default function App() {
         <div style={possibleSocket}>
             <div style={app}>
                 <header style={appHeader}>
-                    <Menu />
+                    {/*<Menu />*/}
                     <Tutorial />
                     <div style={appTitle}>Exquisite Text</div>
                     {/*<GameState />*/}

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -11,7 +11,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 
 import Tutorial from "../Tutorial";
-import Menu from "../Menu";
+// import Menu from "../Menu";
 import {
     appHeader,
     appTitle,
@@ -23,6 +23,8 @@ import type {
     ClientToServerEvents,
     ServerToClientEvents,
 } from "../../types";
+import Paper from "@mui/material/Paper";
+
 
 const isDevelopment = !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 const serverPath: URL["pathname"] | URL["href"] = isDevelopment
@@ -69,8 +71,8 @@ export default function App() {
     }
 
     return (
-        <div style={possibleSocket}>
-            <div style={app}>
+        <div style={possibleSocket} className={"possible-socket"}>
+            <Paper elevation={3} style={app} className={"app-container"}>
                 <header style={appHeader}>
                     {/*<Menu />*/}
                     <Tutorial />
@@ -79,7 +81,7 @@ export default function App() {
                     {/*<Settings />*/}
                 </header>
                 <Outlet context={{ socket }} />
-            </div>
+            </Paper>
         </div>
     );
 }

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -72,7 +72,7 @@ export default function App() {
 
     return (
         <div style={possibleSocket} className={"possible-socket"}>
-            <Paper elevation={3} style={app} className={"app-container"}>
+            <Paper elevation={0} style={app} className={"app-container"}>
                 <header style={appHeader}>
                     {/*<Menu />*/}
                     <Tutorial />

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -10,9 +10,7 @@ import {
 } from "socket.io-client";
 import { v4 as uuidv4 } from "uuid";
 
-import GameState from "../GameState";
 import Tutorial from "../Tutorial";
-import Settings from "../Settings";
 import Menu from "../Menu";
 import {
     appHeader,
@@ -77,8 +75,8 @@ export default function App() {
                     <Menu />
                     <Tutorial />
                     <div style={appTitle}>Exquisite Text</div>
-                    <GameState />
-                    <Settings />
+                    {/*<GameState />*/}
+                    {/*<Settings />*/}
                 </header>
                 <Outlet context={{ socket }} />
             </div>

--- a/src/components/App/styles.ts
+++ b/src/components/App/styles.ts
@@ -18,13 +18,15 @@ export const appTitle: React.CSSProperties = {
 };
 
 export const app: React.CSSProperties = {
-    height: "100%",
-    margin: "0 auto",
-    width: "100%",
+    height: "calc(100vh - 16px)",
+    width: "calc(100vw - 16px)",
+    maxWidth: "90ch",
+    margin: "auto",
 };
 
 export const possibleSocket: React.CSSProperties = {
+    display: "flex",
     height: "100%",
     margin: "0 auto",
-    width: "100%",
+    // width: "calc(100vw - 1px)",
 };

--- a/src/components/App/styles.ts
+++ b/src/components/App/styles.ts
@@ -18,8 +18,8 @@ export const appTitle: React.CSSProperties = {
 };
 
 export const app: React.CSSProperties = {
-    height: "calc(100vh - 16px)",
-    width: "calc(100vw - 16px)",
+    height: "100%",
+    width: "100%",
     maxWidth: "90ch",
     margin: "auto",
 };

--- a/src/components/CreateGame/index.tsx
+++ b/src/components/CreateGame/index.tsx
@@ -37,9 +37,9 @@ function CreateGame() {
                 <Box>
                     <Fab
                         size="small"
-                        color="secondary"
+                        color="primary"
                         aria-label="new"
-                        sx={{position: "absolute", left: "55px", top: "10px"}}
+                        sx={{position: "absolute", left: "54px", top: "10px"}}
                         onClick={handleClick}
                     >
                         <GamepadIcon />

--- a/src/components/CreateGame/index.tsx
+++ b/src/components/CreateGame/index.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import GamepadIcon from "@mui/icons-material/Gamepad";
+import Fab from "@mui/material/Fab";
+import WarningIcon from "@mui/icons-material/Warning";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import { ClickAwayListener } from "@mui/material";
+import { SxProps } from "@mui/system";
+import { Link as RouterLink } from "react-router-dom";
+
+function CreateGame() {
+    const [ open, setOpen ] = React.useState(false);
+    const handleClick = () => {
+        setOpen((prev) => !prev);
+    };
+    const handleClickAway = () => {
+        setOpen(false);
+    };
+    const styles: SxProps = {
+        position: "absolute",
+        top: 60,
+        left: 10,
+        zIndex: 1,
+        border: "1px solid",
+        p: 1,
+        bgcolor: "background.paper",
+        width: 170,
+        marginRight: 0,
+        marginLeft: "auto",
+        fontFamily: "sans-serif",
+    };
+
+    return (
+        <div className={"create-game-fab"}>
+            <ClickAwayListener onClickAway={handleClickAway}>
+                <Box>
+                    <Fab
+                        size="small"
+                        color="secondary"
+                        aria-label="new"
+                        sx={{position: "absolute", left: "55px", top: "10px"}}
+                        onClick={handleClick}
+                    >
+                        <GamepadIcon />
+                    </Fab>
+                    {open
+                        ? (
+                            <Box sx={styles}>
+                                <p style={{ margin: "0 0 0.5em 0" }}><WarningIcon />
+                                    Host new game?</p>
+                                <Stack spacing={2} direction="row"
+                                    style={{ justifyContent: "center" }}>
+                                    <Button variant="outlined" onClick={handleClickAway}>No</Button>
+                                    <Button
+                                        variant="contained"
+                                        component={RouterLink}
+                                        to="host"
+                                        onClick={handleClickAway}
+                                    >
+                                        Yes
+                                    </Button>
+                                </Stack>
+                            </Box>
+                        )
+                        : null}
+                </Box>
+            </ClickAwayListener>
+        </div>
+    );
+}
+
+export default CreateGame;

--- a/src/components/CreateGame/index.tsx
+++ b/src/components/CreateGame/index.tsx
@@ -19,8 +19,8 @@ function CreateGame() {
     };
     const styles: SxProps = {
         position: "absolute",
-        top: 60,
-        left: 10,
+        top: 80,
+        left: "calc(50vw - 40ch - 10px)",
         zIndex: 1,
         border: "1px solid",
         p: 1,
@@ -39,7 +39,7 @@ function CreateGame() {
                         size="small"
                         color="primary"
                         aria-label="new"
-                        sx={{position: "absolute", left: "54px", top: "10px"}}
+                        sx={{position: "absolute", left: "calc(50vw - 40ch - 20px)", top: "20px"}}
                         onClick={handleClick}
                     >
                         <GamepadIcon />

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -28,8 +28,7 @@ function Leave() {
     const styles: SxProps = {
         position: "absolute",
         top: 60,
-        right: 0,
-        left: 0,
+        right: 10,
         zIndex: 1,
         border: "1px solid",
         p: 1,

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -5,10 +5,12 @@ import {
 } from "../LineInput/styles";
 import LogoutIcon from "@mui/icons-material/Logout";
 import Fab from "@mui/material/Fab";
-import Popper from "@mui/material/Popper";
 import WarningIcon from "@mui/icons-material/Warning";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import { ClickAwayListener } from "@mui/material";
+import { SxProps } from "@mui/system";
 
 function Leave() {
     const { socket } = useSocket();
@@ -16,44 +18,56 @@ function Leave() {
     const handleLeave = () => {
         socket.emit("leave");
     };
-
-    const [ anchorEl, setAnchorEl ] = React.useState<null | HTMLElement>(null);
-    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        setAnchorEl(anchorEl
-            ? null
-            : event.currentTarget);
+    const [ open, setOpen ] = React.useState(false);
+    const handleClick = () => {
+        setOpen((prev) => !prev);
     };
-    const handleClose = () => {
-        setAnchorEl(null);
+    const handleClickAway = () => {
+        setOpen(false);
     };
-    const open = Boolean(anchorEl);
-    const id = open
-        ? "simple-popper"
-        : undefined;
+    const styles: SxProps = {
+        position: "absolute",
+        top: 60,
+        right: 0,
+        left: 0,
+        zIndex: 1,
+        border: "1px solid",
+        p: 1,
+        bgcolor: "background.paper",
+        width: 170,
+        marginRight: 0,
+        marginLeft: "auto",
+        fontFamily: "sans-serif",
+    };
 
     return (
         <div className={"leave-game-accordion"} style={accordionDiv}>
-            <Fab
-                size="small"
-                color="secondary"
-                aria-label="logout"
-                sx={{position: "absolute", right: "10px", top: "10px"}}
-                onClick={handleClick}
-            >
-                <LogoutIcon />
-            </Fab>
-            <Popper
-                anchorEl={anchorEl}
-                id={id}
-                open={open}
-            >
-                <p style={{margin: "1em"}}><WarningIcon />
-                    Want to leave the room?</p>
-                <Stack spacing={2} direction="row" style={{ justifyContent: "center", marginBottom: "1em" }}>
-                    <Button variant="outlined" onClick={handleClose}>No</Button>
-                    <Button variant="contained" onClick={handleLeave}>Yes</Button>
-                </Stack>
-            </Popper>
+            <ClickAwayListener onClickAway={handleClickAway}>
+                <Box>
+                    <Fab
+                        size="small"
+                        color="secondary"
+                        aria-label="logout"
+                        sx={{position: "absolute", right: "10px", top: "10px"}}
+                        onClick={handleClick}
+                    >
+                        <LogoutIcon />
+                    </Fab>
+                    {open
+                        ? (
+                            <Box sx={styles}>
+                                <p style={{ margin: "0 0 0.5em 0" }}><WarningIcon />
+                                    Want to leave the room?</p>
+                                <Stack spacing={2} direction="row"
+                                    style={{ justifyContent: "center" }}>
+                                    <Button variant="outlined" onClick={handleClickAway}>No</Button>
+                                    <Button variant="contained" onClick={handleLeave}>Yes</Button>
+                                </Stack>
+                            </Box>
+                        )
+                        : null}
+                </Box>
+            </ClickAwayListener>
         </div>
     );
 }

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -27,8 +27,8 @@ function Leave() {
     };
     const styles: SxProps = {
         position: "absolute",
-        top: 60,
-        right: 10,
+        top: 80,
+        right: "calc(50vw - 40ch - 60px)",
         zIndex: 1,
         border: "1px solid",
         p: 1,
@@ -47,7 +47,7 @@ function Leave() {
                         size="small"
                         color="secondary"
                         aria-label="logout"
-                        sx={{position: "absolute", right: "10px", top: "10px"}}
+                        sx={{position: "absolute", right: "calc(50vw - 40ch - 60px)", top: "20px"}}
                         onClick={handleClick}
                     >
                         <LogoutIcon />

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -5,7 +5,7 @@ import {
 } from "../LineInput/styles";
 import LogoutIcon from "@mui/icons-material/Logout";
 import Fab from "@mui/material/Fab";
-import Popover from "@mui/material/Popover";
+import Popper from "@mui/material/Popper";
 import WarningIcon from "@mui/icons-material/Warning";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
@@ -17,16 +17,18 @@ function Leave() {
         socket.emit("leave");
     };
 
-    const [ anchorEl, setAnchorEl ] = React.useState<Element | null>(null);
-    const handleClick = (event: { currentTarget: React.SetStateAction<Element | null> }) => {
-        setAnchorEl(event.currentTarget);
+    const [ anchorEl, setAnchorEl ] = React.useState<null | HTMLElement>(null);
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(anchorEl
+            ? null
+            : event.currentTarget);
     };
     const handleClose = () => {
         setAnchorEl(null);
     };
-    const isOpen = Boolean(anchorEl);
-    const id = isOpen
-        ? "simple-popover"
+    const open = Boolean(anchorEl);
+    const id = open
+        ? "simple-popper"
         : undefined;
 
     return (
@@ -40,15 +42,10 @@ function Leave() {
             >
                 <LogoutIcon />
             </Fab>
-            <Popover
+            <Popper
                 anchorEl={anchorEl}
-                anchorOrigin={{
-                    horizontal: "left",
-                    vertical: "bottom",
-                }}
                 id={id}
-                onClose={handleClose}
-                open={isOpen}
+                open={open}
             >
                 <p style={{margin: "1em"}}><WarningIcon />
                     Want to leave the room?</p>
@@ -56,7 +53,7 @@ function Leave() {
                     <Button variant="outlined" onClick={handleClose}>No</Button>
                     <Button variant="contained" onClick={handleLeave}>Yes</Button>
                 </Stack>
-            </Popover>
+            </Popper>
         </div>
     );
 }

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -1,63 +1,62 @@
 import * as React from "react";
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import Button from "@mui/material/Button";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-
-import Typography from "@mui/material/Typography";
-import AccordionDetails from "@mui/material/AccordionDetails";
-
 import { useSocket } from "../App";
 import {
-    accordionButton,
-    accordionText,
-    accordionTitle,
+    accordionDiv,
 } from "../LineInput/styles";
+import LogoutIcon from "@mui/icons-material/Logout";
+import Fab from "@mui/material/Fab";
+import Popover from "@mui/material/Popover";
+import WarningIcon from "@mui/icons-material/Warning";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
 
 function Leave() {
     const { socket } = useSocket();
 
-    const handleLeaveButton = () => {
+    const handleLeave = () => {
         socket.emit("leave");
     };
 
+    const [ anchorEl, setAnchorEl ] = React.useState<Element | null>(null);
+    const handleClick = (event: { currentTarget: React.SetStateAction<Element | null> }) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+    const isOpen = Boolean(anchorEl);
+    const id = isOpen
+        ? "simple-popover"
+        : undefined;
+
     return (
-        <div className={"leave-game-accordion"} style={{ marginTop: "1em" }}>
-            <Accordion>
-                <AccordionSummary
-                    aria-controls="panel1a-content"
-                    expandIcon={<ExpandMoreIcon />}
-                    id="panel1a-header"
-                >
-                    <div
-                        className={"leave-game-accordion-title"}
-                        style={accordionTitle}
-                    >
-                        <Typography>
-                            <strong>Need to leave the game early?</strong>
-                        </Typography>
-                    </div>
-                </AccordionSummary>
-                <AccordionDetails>
-                    <div
-                        className={"leave-game-accordion-text"}
-                        style={accordionText}
-                    >
-                        Only press this button if you are absolutely certain you want to leave!
-                    </div>
-                    <div
-                        className={"leave-game-button"}
-                        style={accordionButton}
-                    >
-                        <Button
-                            onClick={handleLeaveButton}
-                            variant="contained"
-                        >
-                            Leave Game
-                        </Button>
-                    </div>
-                </AccordionDetails>
-            </Accordion>
+        <div className={"leave-game-accordion"} style={accordionDiv}>
+            <Fab
+                size="small"
+                color="secondary"
+                aria-label="logout"
+                sx={{position: "absolute", right: "10px", top: "10px"}}
+                onClick={handleClick}
+            >
+                <LogoutIcon />
+            </Fab>
+            <Popover
+                anchorEl={anchorEl}
+                anchorOrigin={{
+                    horizontal: "left",
+                    vertical: "bottom",
+                }}
+                id={id}
+                onClose={handleClose}
+                open={isOpen}
+            >
+                <p style={{margin: "1em"}}><WarningIcon />
+                    Want to leave the room?</p>
+                <Stack spacing={2} direction="row" style={{ justifyContent: "center", marginBottom: "1em" }}>
+                    <Button variant="outlined" onClick={handleClose}>No</Button>
+                    <Button variant="contained" onClick={handleLeave}>Yes</Button>
+                </Stack>
+            </Popover>
         </div>
     );
 }

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -100,8 +100,8 @@ const LineInput = () => {
     };
     const styles: SxProps = {
         position: "absolute",
-        top: 60,
-        right: 60,
+        top: 80,
+        right: "calc(50vw - 40ch - 10px)",
         zIndex: 1,
         border: "1px solid",
         p: 1,
@@ -516,7 +516,7 @@ const LineInput = () => {
                             size="small"
                             color="primary"
                             aria-label="complete"
-                            sx={{ position: "absolute", right: "60px", top: "10px" }}
+                            sx={{ position: "absolute", right: "calc(50vw - 40ch - 10px)", top: "20px" }}
                             onClick={handleClick}
                             disabled={!poemDoneVisible}
                         >

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -1,19 +1,13 @@
 /* eslint-disable sort-keys */
-import Accordion from "@mui/material/Accordion";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import AccordionSummary from "@mui/material/AccordionSummary";
 import Button from "@mui/material/Button";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import Typography from "@mui/material/Typography";
+import Fab from "@mui/material/Fab";
+import PlaylistAddCheckIcon from "@mui/icons-material/PlaylistAddCheck";
 import isNil from "lodash/isNil";
 import * as React from "react";
 
 import { useSocket } from "../App";
 import "./LineInput.css";
 import {
-    accordionButton,
-    accordionText,
-    accordionTitle,
     activeInput,
     caret,
     errorMessage,
@@ -35,6 +29,9 @@ import {
     IGameSettingsInfo,
     LineLength,
 } from "../../types";
+import WarningIcon from "@mui/icons-material/Warning";
+import Stack from "@mui/material/Stack";
+import Popover from "@mui/material/Popover";
 
 // if activeEditor, the letters are visible and textarea is editable
 // if inactiveEditor, the letters are invisible, and textarea is not editable
@@ -88,6 +85,17 @@ const lineConstraints: ILineConstraintDict = {
 
 const LineInput = () => {
     const { socket } = useSocket();
+    const [ anchorEl, setAnchorEl ] = React.useState<Element | null>(null);
+    const handleClick = (event: { currentTarget: React.SetStateAction<Element | null> }) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+    const isOpen = Boolean(anchorEl);
+    const id = isOpen
+        ? "simple-popover"
+        : undefined;
 
     const [ lineLength, setLineLength ] = React.useState<LineLength>(LineLength.short);
     const [ minCharsOnLineOne, setMinCharsOnLineOne ] = React.useState<number>(lineConstraints[LineLength.short]["minCharsOnLineOne"]);
@@ -487,48 +495,33 @@ const LineInput = () => {
                         </Button>
                     </div>
                 </div>
-                {poemDoneVisible && (
-                    <div
-                        className={"done-poem-accordion"}
-                    >
-                        <Accordion>
-                            <AccordionSummary
-                                expandIcon={<ExpandMoreIcon />}
-                                aria-controls="panel1a-content"
-                                id="panel1a-header"
-                            >
-                                <div
-                                    className={"done-poem-accordion-title"}
-                                    style={accordionTitle}
-                                >
-                                    <Typography>
-                                        <strong>Does the poem seem like it is done?</strong>
-                                    </Typography>
-                                </div>
-                            </AccordionSummary>
-                            <AccordionDetails>
-                                <div
-                                    className={"done-poem-accordion-text"}
-                                    style={accordionText}
-                                >
-                  Only press this button if you are absolutely certain the poem
-                  is done!
-                                </div>
-                                <div
-                                    className={"done-poem-button"}
-                                    style={accordionButton}
-                                >
-                                    <Button
-                                        variant={"contained"}
-                                        onClick={completePoem}
-                                    >
-                    Complete Poem
-                                    </Button>
-                                </div>
-                            </AccordionDetails>
-                        </Accordion>
-                    </div>
-                )}
+                <Fab
+                    size="small"
+                    color="primary"
+                    aria-label="complete"
+                    sx={{position: "absolute", right: "60px", top: "10px"}}
+                    onClick={handleClick}
+                    disabled={!poemDoneVisible}
+                >
+                    <PlaylistAddCheckIcon />
+                </Fab>
+                <Popover
+                    anchorEl={anchorEl}
+                    anchorOrigin={{
+                        horizontal: "left",
+                        vertical: "bottom",
+                    }}
+                    id={id}
+                    onClose={handleClose}
+                    open={isOpen}
+                >
+                    <p style={{margin: "1em"}}><WarningIcon />
+                        Want to complete the poem early?</p>
+                    <Stack spacing={2} direction="row" style={{ justifyContent: "center", marginBottom: "1em" }}>
+                        <Button variant="outlined" onClick={handleClose}>No</Button>
+                        <Button variant="contained" onClick={completePoem}>Yes</Button>
+                    </Stack>
+                </Popover>
             </div>
         </div>
     );

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -31,7 +31,9 @@ import {
 } from "../../types";
 import WarningIcon from "@mui/icons-material/Warning";
 import Stack from "@mui/material/Stack";
-import Popper from "@mui/material/Popper";
+import Box from "@mui/material/Box";
+import { ClickAwayListener } from "@mui/material";
+import { SxProps } from "@mui/system";
 
 // if activeEditor, the letters are visible and textarea is editable
 // if inactiveEditor, the letters are invisible, and textarea is not editable
@@ -86,19 +88,30 @@ const lineConstraints: ILineConstraintDict = {
 const LineInput = () => {
     const { socket } = useSocket();
 
-    const [ anchorEl, setAnchorEl ] = React.useState<null | HTMLElement>(null);
-    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-        setAnchorEl(anchorEl
-            ? null
-            : event.currentTarget);
+    const handleLeave = () => {
+        socket.emit("leave");
     };
-    const handleClose = () => {
-        setAnchorEl(null);
+    const [ open, setOpen ] = React.useState(false);
+    const handleClick = () => {
+        setOpen((prev) => !prev);
     };
-    const open = Boolean(anchorEl);
-    const id = open
-        ? "simple-popper"
-        : undefined;
+    const handleClickAway = () => {
+        setOpen(false);
+    };
+    const styles: SxProps = {
+        position: "absolute",
+        top: 60,
+        right: 0,
+        left: 0,
+        zIndex: 1,
+        border: "1px solid",
+        p: 1,
+        bgcolor: "background.paper",
+        width: 170,
+        marginRight: 0,
+        marginLeft: "auto",
+        fontFamily: "sans-serif",
+    };
 
     const [ lineLength, setLineLength ] = React.useState<LineLength>(LineLength.short);
     const [ minCharsOnLineOne, setMinCharsOnLineOne ] = React.useState<number>(lineConstraints[LineLength.short]["minCharsOnLineOne"]);
@@ -498,28 +511,32 @@ const LineInput = () => {
                         </Button>
                     </div>
                 </div>
-                <Fab
-                    size="small"
-                    color="primary"
-                    aria-label="complete"
-                    sx={{position: "absolute", right: "60px", top: "10px"}}
-                    onClick={handleClick}
-                    disabled={!poemDoneVisible}
-                >
-                    <PlaylistAddCheckIcon />
-                </Fab>
-                <Popper
-                    anchorEl={anchorEl}
-                    id={id}
-                    open={open}
-                >
-                    <p style={{margin: "1em"}}><WarningIcon />
-                        Want to complete the poem early?</p>
-                    <Stack spacing={2} direction="row" style={{ justifyContent: "center", marginBottom: "1em" }}>
-                        <Button variant="outlined" onClick={handleClose}>No</Button>
-                        <Button variant="contained" onClick={completePoem}>Yes</Button>
-                    </Stack>
-                </Popper>
+                <ClickAwayListener onClickAway={handleClickAway}>
+                    <Box>
+                        <Fab
+                            size="small"
+                            color="primary"
+                            aria-label="complete"
+                            sx={{ position: "absolute", right: "60px", top: "10px" }}
+                            onClick={handleClick}
+                            disabled={!poemDoneVisible}
+                        >
+                            <PlaylistAddCheckIcon />
+                        </Fab>
+                        {open
+                            ? (
+                                <Box sx={styles}>
+                                    <p style={{ margin: "0 0 0.5em 0" }}><WarningIcon />
+                                        Want to complete the poem early?</p>
+                                    <Stack spacing={2} direction="row" style={{ justifyContent: "center" }}>
+                                        <Button variant="outlined" onClick={handleClickAway}>No</Button>
+                                        <Button variant="contained" onClick={completePoem}>Yes</Button>
+                                    </Stack>
+                                </Box>
+                            )
+                            : null}
+                    </Box>
+                </ClickAwayListener>
             </div>
         </div>
     );

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -101,8 +101,7 @@ const LineInput = () => {
     const styles: SxProps = {
         position: "absolute",
         top: 60,
-        right: 0,
-        left: 0,
+        right: 60,
         zIndex: 1,
         border: "1px solid",
         p: 1,

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -31,7 +31,7 @@ import {
 } from "../../types";
 import WarningIcon from "@mui/icons-material/Warning";
 import Stack from "@mui/material/Stack";
-import Popover from "@mui/material/Popover";
+import Popper from "@mui/material/Popper";
 
 // if activeEditor, the letters are visible and textarea is editable
 // if inactiveEditor, the letters are invisible, and textarea is not editable
@@ -85,16 +85,19 @@ const lineConstraints: ILineConstraintDict = {
 
 const LineInput = () => {
     const { socket } = useSocket();
-    const [ anchorEl, setAnchorEl ] = React.useState<Element | null>(null);
-    const handleClick = (event: { currentTarget: React.SetStateAction<Element | null> }) => {
-        setAnchorEl(event.currentTarget);
+
+    const [ anchorEl, setAnchorEl ] = React.useState<null | HTMLElement>(null);
+    const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(anchorEl
+            ? null
+            : event.currentTarget);
     };
     const handleClose = () => {
         setAnchorEl(null);
     };
-    const isOpen = Boolean(anchorEl);
-    const id = isOpen
-        ? "simple-popover"
+    const open = Boolean(anchorEl);
+    const id = open
+        ? "simple-popper"
         : undefined;
 
     const [ lineLength, setLineLength ] = React.useState<LineLength>(LineLength.short);
@@ -505,15 +508,10 @@ const LineInput = () => {
                 >
                     <PlaylistAddCheckIcon />
                 </Fab>
-                <Popover
+                <Popper
                     anchorEl={anchorEl}
-                    anchorOrigin={{
-                        horizontal: "left",
-                        vertical: "bottom",
-                    }}
                     id={id}
-                    onClose={handleClose}
-                    open={isOpen}
+                    open={open}
                 >
                     <p style={{margin: "1em"}}><WarningIcon />
                         Want to complete the poem early?</p>
@@ -521,7 +519,7 @@ const LineInput = () => {
                         <Button variant="outlined" onClick={handleClose}>No</Button>
                         <Button variant="contained" onClick={completePoem}>Yes</Button>
                     </Stack>
-                </Popover>
+                </Popper>
             </div>
         </div>
     );

--- a/src/components/LineInput/styles.ts
+++ b/src/components/LineInput/styles.ts
@@ -13,11 +13,14 @@ export const activeInput: React.CSSProperties = {
     margin: "auto",
     maxWidth: "60ch",
     width: "100%",
+    // position: "fixed",
+    // left: "50%",
+    // transform: "translateX(-50%)",
 };
 
 export const accordionDiv: React.CSSProperties = {
     margin: "1em auto",
-    maxWidth: "24em",
+    maxWidth: "60ch",
 };
 
 export const accordionTitle: React.CSSProperties = {
@@ -104,7 +107,7 @@ export const helpMessageStyle: React.CSSProperties = {
 
 export const lineInputContainer: React.CSSProperties = {
     marginTop: "2em",
-    width: "100%",
+    // width: "100%",
 };
 
 export const mainInputContainer: React.CSSProperties = {
@@ -112,9 +115,9 @@ export const mainInputContainer: React.CSSProperties = {
     display: "flex",
     flexDirection: "column",
     flexWrap: "nowrap",
-    height: "100%",
+    // height: "100%",
     justifyContent: "space-between",
-    width: "100%",
+    // width: "100%",
 };
 
 export const inactiveInput: React.CSSProperties = {

--- a/src/components/LineInput/styles.ts
+++ b/src/components/LineInput/styles.ts
@@ -15,6 +15,11 @@ export const activeInput: React.CSSProperties = {
     width: "100%",
 };
 
+export const accordionDiv: React.CSSProperties = {
+    margin: "1em auto",
+    maxWidth: "24em",
+};
+
 export const accordionTitle: React.CSSProperties = {
     margin: "auto",
 };
@@ -95,15 +100,6 @@ export const helpMessageStyle: React.CSSProperties = {
     fontFamily: "sans-serif",
     height: "1.2em",
     whiteSpace: "pre-line",
-};
-
-export const accordionButton: React.CSSProperties = {
-    textAlign: "center",
-};
-
-export const accordionText: React.CSSProperties = {
-    fontFamily: "sans-serif",
-    marginBottom: "1em",
 };
 
 export const lineInputContainer: React.CSSProperties = {

--- a/src/components/Lines/index.tsx
+++ b/src/components/Lines/index.tsx
@@ -9,10 +9,12 @@ const Lines = () => {
     const [ lineEdits, setLineEdits ] = React.useState<Array<string>>([ "", "", "", "" ]);
 
     React.useEffect(() => {
+        // const clearLinesListener = () => {
+        //     setLines([ [], [], [], [] ]);
+        // };
+
         const lineSpectatorListener = (poemIndex: number, line: string) => {
             setLines(prevLines => {
-                console.log(prevLines);
-                console.log(prevLines[poemIndex]);
                 return [ ...prevLines.slice(0, poemIndex), [ ...prevLines[poemIndex], line ], ...prevLines.slice(poemIndex + 1) ];
             },
             );
@@ -30,9 +32,11 @@ const Lines = () => {
 
         socket.on("lineSpectator", lineSpectatorListener);
         socket.on("lineEditSpectator", lineEditSpectatorListener);
+        // socket.on("clearLines", clearLinesListener);
 
         // tells the server for this client to do getLines
         // since this is client-side, it only happens for this client
+        setLines([ [], [], [], [] ]);
         socket.emit("getLines");
 
         return () => {
@@ -42,7 +46,7 @@ const Lines = () => {
     }, [ socket ]);
 
     return (
-        <div style={
+        <div className={"lines-outer"} style={
             {
                 fontFamily: "'Esteban', serif",
                 fontSize: "18px",
@@ -52,11 +56,11 @@ const Lines = () => {
             }
         }>
             {lines.map((lineArray, poemIndex) => {
-                return <div style={{ marginBottom: "2em" }} key={poemIndex}>
-                    <div>{
+                return <div className={"lines-inner"} style={{ marginBottom: "2em" }} key={poemIndex}>
+                    <div className={"lines-array"}>{
                         lineArray.join("\n")
                     }</div>
-                    <div>{lineEdits[poemIndex]}</div>
+                    <div className={"lines-edit"}>{lineEdits[poemIndex]}</div>
                 </div>;
             },
             )}

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -25,7 +25,7 @@ const Tutorial = () => {
     const handleHelpClose = () => setHelpOpen(false);
 
     return (
-        <div className={"tutorial"} style={{marginLeft: "3px"}}>
+        <div className={".mui-fixed"} style={{ position: "absolute", right: "calc(50vw + 40ch - 10px)", top: "16px" }}>
             <IconButton aria-label="info" onClick={handleHelpOpen} size={"large"}>
                 <InfoOutlinedIcon />
             </IconButton>

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -25,7 +25,7 @@ const Tutorial = () => {
     const handleHelpClose = () => setHelpOpen(false);
 
     return (
-        <div className={"tutorial"}>
+        <div className={"tutorial"} style={{marginLeft: "0", marginRight: "auto"}}>
             <IconButton aria-label="info" onClick={handleHelpOpen} size={"large"}>
                 <InfoOutlinedIcon />
             </IconButton>

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -25,7 +25,7 @@ const Tutorial = () => {
     const handleHelpClose = () => setHelpOpen(false);
 
     return (
-        <div className={"tutorial"} style={{marginLeft: "0", marginRight: "auto"}}>
+        <div className={"tutorial"} style={{marginLeft: "3px"}}>
             <IconButton aria-label="info" onClick={handleHelpOpen} size={"large"}>
                 <InfoOutlinedIcon />
             </IconButton>

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,20 @@
+/** {*/
+/*    margin: 0;*/
+/*    padding: 0;*/
+/*}*/
+
 #root {
     margin: 0 auto;
     height: 100%;
-    width: 100%
+    /*width: 100%;*/
+    /*max-width: 1440px;*/
 }
 
 html,
 body {
     margin: 0 auto;
     height: 100%;
-    width: 100%
+    /*width: calc(100vw - 1px);*/
 }
 
 body {

--- a/src/screens/Game/index.tsx
+++ b/src/screens/Game/index.tsx
@@ -4,11 +4,11 @@ import GameTransition from "../../components/GameTransition";
 import Leave from "../../components/Leave";
 import LineInput from "../../components/LineInput";
 import Poems from "../../components/Poems";
-import { appBody } from "./styles";
+import { gameContainer } from "./styles";
 
 function Game() {
     return (
-        <div style={appBody}>
+        <div style={gameContainer} className={"game-container"}>
             <LineInput />
             <Leave />
             <Poems />

--- a/src/screens/Game/styles.ts
+++ b/src/screens/Game/styles.ts
@@ -1,13 +1,13 @@
 import * as React from "react";
 
-export const appBody: React.CSSProperties = {
+export const gameContainer: React.CSSProperties = {
     alignItems: "center",
     display: "flex",
     flexDirection: "column",
     flexWrap: "nowrap",
     fontFamily: "'Esteban', serif",
     fontSize: "18px",
-    height: "calc(100vh - 60px)",
+    height: "calc(100vh - 76px)",
     justifyContent: "flex-start",
-    width: "99vw",
+    // width: "99vw",
 };

--- a/src/screens/Join/index.tsx
+++ b/src/screens/Join/index.tsx
@@ -5,6 +5,7 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import { useSocket } from "../../components/App";
+import CreateGame from "../../components/CreateGame";
 
 export default function Join() {
     const navigate = useNavigate();
@@ -122,6 +123,7 @@ export default function Join() {
                 }}>
                 {joinErrorMessage}
             </div>
+            <CreateGame />
         </div>
     );
 }

--- a/src/screens/Lobby/index.tsx
+++ b/src/screens/Lobby/index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import GameSettings from "../../components/GameSettings";
 import GameTransition from "../../components/GameTransition";
+import Leave from "../../components/Leave";
 import UserTable from "../../components/UserTable";
 
 function Lobby() {
@@ -9,6 +10,7 @@ function Lobby() {
         <div >
             <UserTable />
             <GameSettings />
+            <Leave />
             <GameTransition />
         </div>
     );

--- a/src/screens/Spectate/index.tsx
+++ b/src/screens/Spectate/index.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 
 import GameTransition from "../../components/GameTransition";
 import Lines from "../../components/Lines";
+import Leave from "../../components/Leave";
 
 function Spectate() {
     return (
         <div>
             <Lines />
+            <Leave />
             <GameTransition />
         </div>
     );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,7 +54,6 @@ export interface IObjectStringToString {
 }
 
 export interface ServerToClientEvents {
-    clearLines: () => void;
     line: (a: ILine) => void;
     lineEdit: (a: string) => void;
     lineEditSize: (a: number, b: number) => void;
@@ -79,7 +78,6 @@ export interface ClientToServerEvents {
     lineEdit: (a: string) => void;
     line: (a: string) => void;
     poemDone: () => void;
-    clearLines: () => void;
     getLines: () => void;
     getPoems: () => void;
 


### PR DESCRIPTION
This is an experimental branch that contains a sketch of how to deal with the UI design related to the "Complete Poem" and "Leave Room" buttons.

Previously, these were buttons contained within Accordion elements.

Now, they are floating action buttons (FABs) that are positioned absolutely in the top right corner of the "Game" view. Clicking the button opens up a confirmation popover that contains a warning symbol and bit of text that indirectly describes what the button does: "Want to complete the poem early?" and "Want to leave the room?"

These are in the spots where the previous unused GameState and Settings buttons were, so those components are unused here.

Again, this is experimental so don't merge this until we've had a chance to talk about it.