### PR TITLE
Leaving and afk improvements

### DIFF
--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -253,6 +253,12 @@ class Member {
 
         console.log(this.socket.id, "disconnected");
 
+        // if in the room but the game hasn't started yet (lobby), remove them
+        const thisRoom = roomIDToRoom.get(this.roomID);
+        if (!thisRoom.gameOngoing) {
+            this.leaveRoom();
+        }
+
         // socketIDToDeviceID
         // deviceIDToSocketID
         // roomIDToRoom
@@ -351,6 +357,7 @@ class Editor extends Member {
         this.turnPosition = 0;
         this.poemQueue = [];
         this.isCurrentlyEditing = false;
+        this.lastActivity = new Date();
     }
 
     prepareForGame() {

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -64,12 +64,10 @@ class Room {
 
     editors: Map<string, Editor>;
     spectators: Map<string, Spectator>;
-    // editorNames: Array<string>;
-    // spectatorNames: Array<string>;
     gameSettings: IGameSettingsInfo;
     gameOngoing: boolean;
     nPoemsInRotation: number;
-    activityInterval: any;
+    activityInterval: ReturnType<typeof setInterval>;
 
     constructor(
         io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
@@ -82,8 +80,6 @@ class Room {
 
         this.editors = new Map();    // deviceID to editorObj
         this.spectators = new Map(); // deviceID to spectatorObj
-        // this.editorNames = [];       // deviceID to editorObj
-        // this.spectatorNames = [];    // deviceID to spectatorObj
         this.gameSettings = defaultGameSettings;
         this.gameOngoing = false;
         this.nPoemsInRotation = 0;
@@ -94,7 +90,6 @@ class Room {
 
     addEditor(deviceUUID: string, editorObj: Editor) {
         this.editors.set(deviceUUID, editorObj);
-        // this.editorNames.push(editorObj.name);
         this.sendCurrentUserTableInfo(); // give the room updated user info
     }
 
@@ -105,7 +100,6 @@ class Room {
 
     addSpectator(deviceUUID: string, spectatorObj: Spectator) {
         this.spectators.set(deviceUUID, spectatorObj);
-        // this.spectatorNames.push(spectatorObj.name);
         this.sendCurrentUserTableInfo(); // give the room updated user info
     }
 

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -31,7 +31,8 @@ const defaultGameSettings: IGameSettingsInfo = {
     nPoems: 1,
     nRounds: 2,
 };
-
+const activityTimeout = 180000; // ms
+const checkActivityInterval = 30000; // ms
 
 // this function grabs some old poems to have something to show the users
 async function populatePoems() {
@@ -84,6 +85,9 @@ class Room {
         this.gameSettings = defaultGameSettings;
         this.gameOngoing = false;
         this.nPoemsInRotation = 0;
+
+        // check user activity every 30 seconds
+        setInterval(this.checkActivity.bind(this), checkActivityInterval);
     }
 
     addEditor(deviceUUID: string, editorObj: Editor) {
@@ -157,6 +161,23 @@ class Room {
         }
     }
 
+    checkActivity() {
+        const currentTime = Date.now();
+        console.log("checking activity at", currentTime);
+        for (const thisSpectator of this.spectators.values()) {
+            if (!thisSpectator.connected && (currentTime - thisSpectator.lastActivity) > activityTimeout) {
+                thisSpectator.leaveRoom();
+                console.log("booting", thisSpectator.name, "based on inactivity");
+            }
+        }
+        for (const thisEditor of this.editors.values()) {
+            if (thisEditor.isCurrentlyEditing && ((currentTime - thisEditor.lastActivity) > activityTimeout)) {
+                thisEditor.leaveRoom();
+                console.log("booting", thisEditor.name, "based on inactivity");
+            }
+        }
+    }
+
 }
 
 class Member {
@@ -170,6 +191,8 @@ class Member {
     roomID: string;
     deviceID: string;
     name: string;
+    lastActivity: number;
+    connected: boolean;
 
     constructor(
         io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
@@ -183,14 +206,18 @@ class Member {
         this.roomID = roomID;
         this.deviceID = deviceID;
         this.name = name;
+        this.lastActivity = Date.now(); // current time since epoch in ms
+        this.connected = true;
     }
 
     joinRoom() {
+        this.connected = true;
         this.socket.join(this.roomID);
         this.setReceive(); // listen for certain messages from client
     }
 
     leaveRoom() {
+        this.connected = false;
         console.log(this.name, " leaving ", this. roomID);
         this.io.to(this.socket.id).emit("navigate", "/"); // navigate home (if possible)
         delete deviceIDToRoomID[this.deviceID];
@@ -252,6 +279,7 @@ class Member {
         // however if they are AFK, etc, we should do those things
 
         console.log(this.socket.id, "disconnected");
+        this.connected = false;
 
         // if in the room but the game hasn't started yet (lobby), remove them
         const thisRoom = roomIDToRoom.get(this.roomID);
@@ -336,6 +364,11 @@ class Spectator extends Member {
             }
         }
     }
+
+    disconnect() {
+        this.lastActivity = Date.now(); // refresh activity
+        super.disconnect();
+    }
 }
 
 class Editor extends Member {
@@ -357,7 +390,6 @@ class Editor extends Member {
         this.turnPosition = 0;
         this.poemQueue = [];
         this.isCurrentlyEditing = false;
-        this.lastActivity = new Date();
     }
 
     prepareForGame() {
@@ -441,6 +473,9 @@ class Editor extends Member {
         // for the spectator, TBD
 
         // for now, only send to the next Editor in line (each watches who are behind them)
+
+        this.lastActivity = Date.now();  // they typed = active
+
         const thisRoom = roomIDToRoom.get(this.roomID);
         this.io.to(thisRoom.editors.get(this.targetEditorID).socket.id).emit("lineEditorWatch", value);
 
@@ -477,6 +512,7 @@ class Editor extends Member {
 
     possibleStartNewTurn() {
         if (this.hasPoemInQueue()) {
+            this.lastActivity = Date.now(); // give them some time to type
             this.io.to(this.socket.id).emit("lineEdit", this.poemQueue[0].halfLine);
             const thisPoem = this.poemQueue[0];
             console.log("we think the poem has", thisPoem.lines.length, "submissions so far");

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -38,7 +38,7 @@ const checkActivityInterval = 30000; // ms
 async function populatePoems() {
     const dbPoems = await returnPoems(retrieveNPoemsAtStart) as Array<IPoem>;
     for (const { id, createdAt, title, content } of dbPoems) {
-        poems.add({
+        publicPoems.add({
             content,
             createdAt,
             id,
@@ -53,7 +53,8 @@ const socketIDToDeviceID: IObjectStringToString = {};
 const deviceIDToSocketID: IObjectStringToString = {};  // unique on device. only latest is present
 const deviceIDToRoomID: IObjectStringToString = {};
 const roomIDToRoom: Map<string, any> = new Map();
-const poems: Set<IPoem> = new Set();
+const roomIDToHost: Map<string, Host> = new Map();
+const publicPoems: Set<IPoem> = new Set();
 
 class Room {
     // represents a socket.io room and a game of Exquisite Text
@@ -68,6 +69,7 @@ class Room {
     gameSettings: IGameSettingsInfo;
     gameOngoing: boolean;
     nPoemsInRotation: number;
+    activityInterval: any;
 
     constructor(
         io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
@@ -87,7 +89,7 @@ class Room {
         this.nPoemsInRotation = 0;
 
         // check user activity every 30 seconds
-        setInterval(this.checkActivity.bind(this), checkActivityInterval);
+        this.activityInterval = setInterval(this.checkActivity.bind(this), checkActivityInterval);
     }
 
     addEditor(deviceUUID: string, editorObj: Editor) {
@@ -163,7 +165,7 @@ class Room {
 
     checkActivity() {
         const currentTime = Date.now();
-        console.log("checking activity at", currentTime);
+        console.log(this.roomID, "checking activity at", currentTime);
         for (const thisSpectator of this.spectators.values()) {
             if (!thisSpectator.connected && (currentTime - thisSpectator.lastActivity) > activityTimeout) {
                 thisSpectator.leaveRoom();
@@ -177,7 +179,6 @@ class Room {
             }
         }
     }
-
 }
 
 class Member {
@@ -283,12 +284,14 @@ class Member {
 
         // if in the room but the game hasn't started yet (lobby), remove them
         const thisRoom = roomIDToRoom.get(this.roomID);
-        if (!thisRoom.gameOngoing) {
+        if (!isNil(thisRoom) && !thisRoom.gameOngoing) {
             this.leaveRoom();
         }
 
         // socketIDToDeviceID
+        delete socketIDToDeviceID[this.socket.id];
         // deviceIDToSocketID
+        delete deviceIDToSocketID[this.deviceID];
         // roomIDToRoom
 
         // do cleanup intelligently
@@ -312,7 +315,7 @@ class Member {
 
     getPoems() {
         // this is used to bring a new user up to date on what's happening
-        poems.forEach((poem) => this.sendPoem(poem));
+        publicPoems.forEach((poem) => this.sendPoem(poem));
     }
 
 }
@@ -573,13 +576,38 @@ class Editor extends Member {
         // if all editors' poem queues are empty
         // remove each of the editor/spectator deviceIDs from deviceIDToRoomID
         if (thisRoom.nPoemsInRotation === 0) {
-            console.log("no poems left to finish; forget everyone's device");
-            for (const editorID of thisRoom.editors.keys()) {
+            console.log("no poems left to finish; forget everyone's device, delete room and poem globals");
+            thisRoom.gameOngoing = false;
+            for (const [ editorID, thisEditor ] of thisRoom.editors.entries()) {
                 delete deviceIDToRoomID[editorID];
+                // since thisRoom.editors is a map from editor's device ID to the Member this should delete the object
+                // including its socket?
+                thisEditor.connected = false;
+                delete deviceIDToRoomID[editorID];
+                thisEditor.socket.leave(this.roomID);
+                thisEditor.unsetReceive();
+                delete socketIDToDeviceID[thisEditor.socket.id];
+                delete deviceIDToSocketID[editorID];
+                thisRoom.editors.delete(editorID);
             }
-            for (const spectatorID of thisRoom.spectators.keys()) {
+            for (const [ spectatorID, thisSpectator ] of thisRoom.spectators.entries()) {
                 delete deviceIDToRoomID[spectatorID];
+                thisSpectator.connected = false;
+                delete deviceIDToRoomID[spectatorID];
+                thisSpectator.socket.leave(this.roomID);
+                thisSpectator.unsetReceive();
+                delete socketIDToDeviceID[thisSpectator.socket.id];
+                delete deviceIDToSocketID[spectatorID];
+                thisRoom.spectators.delete(spectatorID);
             }
+            clearInterval(thisRoom.activityInterval);
+            roomIDToHost.delete(this.roomID);
+            roomIDToRoom.delete(this.roomID);
+            // console.log("deviceIDToRoomID", deviceIDToRoomID);
+            // console.log("roomIDToHost", roomIDToHost);
+            // console.log("roomIDToRoom", roomIDToRoom);
+            // console.log("thisRoom.editors", thisRoom.editors);
+            // console.log("thisRoom.spectators", thisRoom.spectators);
         }
     }
 
@@ -591,13 +619,16 @@ class Editor extends Member {
             id: uuidv4(),
             title: `exquisite text #${Math.round(Math.random() * 100)}`,
         };
-        poems.add(poem);
+        publicPoems.add(poem);
 
         // add the poem to the database
         storePoem(poem);
 
-        // broadcast the poem via sockets
+        // broadcast the poem to room members via sockets
         this.sendPoem(poem);
+
+        // delete the global var from public view
+        publicPoems.delete(poem);
     }
 }
 
@@ -707,6 +738,8 @@ function sockets(io: Server<ClientToServerEvents, ServerToClientEvents, InterSer
         // When a client requests a connection, the callback will create a new Connection instance
         // and pass the Socket.IO server instance and the new socket to the constructor.
 
+        // This establishes the callbacks that every socket should have access to.
+
         socket.on("recognizeDevice", (deviceID) => {
 
             console.log("new socket", socket.id, "from device", deviceID);
@@ -749,6 +782,7 @@ function sockets(io: Server<ClientToServerEvents, ServerToClientEvents, InterSer
             // notice we don't add the host device to deviceIDToRoomID
             const thisHost = new Host(io, socket, roomID, socketIDToDeviceID[socket.id], "HOST");
             thisHost.joinRoom();
+            roomIDToHost.set(roomID, thisHost);
             const thisRoom = new Room(io, socket, roomID);
             roomIDToRoom.set(roomID, thisRoom);
             console.log("room", roomID, "created with ", socket.id, "as host");

--- a/src/components/CreateGame/index.tsx
+++ b/src/components/CreateGame/index.tsx
@@ -19,8 +19,8 @@ function CreateGame() {
     };
     const styles: SxProps = {
         position: "absolute",
-        top: 80,
-        left: "calc(50vw - 40ch - 10px)",
+        top: 60,
+        left: 55,
         zIndex: 1,
         border: "1px solid",
         p: 1,
@@ -39,7 +39,10 @@ function CreateGame() {
                         size="small"
                         color="primary"
                         aria-label="new"
-                        sx={{position: "absolute", left: "calc(50vw - 40ch - 20px)", top: "20px"}}
+                        sx={{position: "absolute",
+                            left: "55px",
+                            top: "10px",
+                        }}
                         onClick={handleClick}
                     >
                         <GamepadIcon />

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -27,8 +27,8 @@ function Leave() {
     };
     const styles: SxProps = {
         position: "absolute",
-        top: 80,
-        right: "calc(50vw - 40ch - 60px)",
+        top: 60,
+        right: 20,
         zIndex: 1,
         border: "1px solid",
         p: 1,
@@ -47,7 +47,7 @@ function Leave() {
                         size="small"
                         color="secondary"
                         aria-label="logout"
-                        sx={{position: "absolute", right: "calc(50vw - 40ch - 60px)", top: "20px"}}
+                        sx={{position: "absolute", right: "15px", top: "10px"}}
                         onClick={handleClick}
                     >
                         <LogoutIcon />

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -88,9 +88,6 @@ const lineConstraints: ILineConstraintDict = {
 const LineInput = () => {
     const { socket } = useSocket();
 
-    const handleLeave = () => {
-        socket.emit("leave");
-    };
     const [ open, setOpen ] = React.useState(false);
     const handleClick = () => {
         setOpen((prev) => !prev);

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -97,8 +97,8 @@ const LineInput = () => {
     };
     const styles: SxProps = {
         position: "absolute",
-        top: 80,
-        right: "calc(50vw - 40ch - 10px)",
+        top: 60,
+        right: 65,
         zIndex: 1,
         border: "1px solid",
         p: 1,
@@ -513,7 +513,7 @@ const LineInput = () => {
                             size="small"
                             color="primary"
                             aria-label="complete"
-                            sx={{ position: "absolute", right: "calc(50vw - 40ch - 10px)", top: "20px" }}
+                            sx={{ position: "absolute", right: "64px", top: "10px"}}
                             onClick={handleClick}
                             disabled={!poemDoneVisible}
                         >

--- a/src/components/Tutorial/index.tsx
+++ b/src/components/Tutorial/index.tsx
@@ -25,7 +25,14 @@ const Tutorial = () => {
     const handleHelpClose = () => setHelpOpen(false);
 
     return (
-        <div className={".mui-fixed"} style={{ position: "absolute", right: "calc(50vw + 40ch - 10px)", top: "16px" }}>
+        <div
+            className={".mui-fixed"}
+            style={{
+                position: "absolute",
+                left: "5px",
+                top: "5px",
+            }}
+        >
             <IconButton aria-label="info" onClick={handleHelpOpen} size={"large"}>
                 <InfoOutlinedIcon />
             </IconButton>


### PR DESCRIPTION
Prior to this, if an active editor were to go AFK, everyone else in the room would have no recourse. The game would get stuck and there is no way to forcibly remove anyone.

This adds a mechanism to prevent this that works as follows: 

Major actions refresh a timestamp. For editors, starting a new turn and doing a lineEdit. For spectators, disconnecting (closing the tab).

Every 30 seconds, the Room checks all currently-disconnected spectators (tab-closed) and active editors (currently editing a poem) to see if they've been active in the past 3 minutes. If not, force them to leave the room.