### PR TITLE
feat: intial store and viz lines

### DIFF
--- a/server/entity/line.ts
+++ b/server/entity/line.ts
@@ -1,0 +1,46 @@
+import {
+    DataTypes,
+} from "sequelize";
+import {
+    pgSequelConn,
+} from "./poem";
+
+
+export const Line = pgSequelConn.define(
+    "Line",
+    {
+        // Model attributes are defined here
+        poemID: {
+            allowNull: false,
+            type: DataTypes.CHAR(36), // uuidv4 is always 36 chars
+        },
+        lineIndex: {
+            allowNull: false,
+            type: DataTypes.SMALLINT,
+        },
+        content: {
+            allowNull: false,
+            type: DataTypes.STRING, // same as VARCHAR(255)
+        },
+        authorDevice: {
+            allowNull: false,
+            type: DataTypes.CHAR(36),
+        },
+        passerDevice: {
+            allowNull: false,
+            type: DataTypes.CHAR(36),
+        },
+        editLength: {
+            allowNull: false,
+            type: DataTypes.SMALLINT,
+        },
+        addedAt: {
+            allowNull: false,
+            type: DataTypes.DATE,
+        },
+    },
+    {
+        // Other model options go here
+        timestamps: false,
+    },
+);

--- a/server/queries.ts
+++ b/server/queries.ts
@@ -2,8 +2,10 @@ import {
     pgSequelConn,
     Poem,
 } from "./entity/poem";
-
-import { IPoem } from "../src/types";
+import {
+    Line,
+} from "./entity/line";
+import { IPoem, ILine } from "../src/types";
 
 (async () => {
     try {
@@ -17,6 +19,7 @@ import { IPoem } from "../src/types";
 async function returnPoems(nPoems: number) {
     try {
         await Poem.sync();  // make sure the table exists
+        await Line.sync();  // make sure the table exists
         return await Poem.findAll({
             attributes: [
                 "id",
@@ -45,7 +48,16 @@ async function storePoem({ title, content }: IPoem) {
     }
 }
 
+async function storeLine({poemID, lineIndex, content, authorDevice, passerDevice, editLength, addedAt}: ILine) {
+    try {
+        await Line.create({poemID, lineIndex, content, authorDevice, passerDevice, editLength, addedAt});
+    } catch ({ stack }) {
+        console.log(stack);
+    }
+}
+
 export {
     returnPoems,
     storePoem,
+    storeLine,
 };

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -35,7 +35,7 @@ const defaultGameSettings: IGameSettingsInfo = {
 };
 const activityTimeout = 180000; // ms
 const checkActivityInterval = 30000; // ms
-const editorColorArr = [ "blue", "green", "red", "orange" ];
+const editorColorArr = [ "#4F71BE", "#B86029", "#A9D18E", "#B89230" ];
 
 // this function grabs some old poems to have something to show the users
 async function populatePoems() {

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from "uuid"; // a function that generates a random uuid 
 import {
     ClientToServerEvents,
     IGameSettingsInfo,
+    ILine,
     InterServerEvents,
     IObjectStringToString,
     IPoem,
@@ -22,6 +23,7 @@ import {
 import {
     returnPoems,
     storePoem,
+    storeLine,
 } from "./queries";
 
 const retrieveNPoemsAtStart = 1;
@@ -33,6 +35,7 @@ const defaultGameSettings: IGameSettingsInfo = {
 };
 const activityTimeout = 180000; // ms
 const checkActivityInterval = 30000; // ms
+const editorColorArr = [ "blue", "green", "red", "orange" ];
 
 // this function grabs some old poems to have something to show the users
 async function populatePoems() {
@@ -111,8 +114,10 @@ class Room {
     currentUserTableInfo() {
         const editorNameArr: Array<string> = [];
         const spectatorNameArr: Array<string> = [];
+        const editorColorObj: Record<string, string> = {};
         for (const thisEditor of this.editors.values()) {
             editorNameArr.push(thisEditor.name);
+            editorColorObj[thisEditor.deviceID] = editorColorArr[thisEditor.turnPosition];
         }
         for (const thisSpectator of this.spectators.values()) {
             spectatorNameArr.push(thisSpectator.name);
@@ -120,6 +125,7 @@ class Room {
         return {
             editors: editorNameArr,
             spectators: spectatorNameArr,
+            editorColors: editorColorObj,
         };
     }
 
@@ -137,7 +143,7 @@ class Room {
         for (const thisEditor of this.editors.values()) {
             thisEditor.prepareForGame();
             if (nPoemsToHandOut > 0) {
-                const thisPoem = new Poem(targetLines, poemIndex, this.io, this.roomID);
+                const thisPoem = new Poem(targetLines, poemIndex, this.io, this.roomID); // creates Poem object
                 thisEditor.poemQueue.push(thisPoem);
                 thisEditor.isCurrentlyEditing = true;
                 nPoemsToHandOut--;
@@ -234,6 +240,7 @@ class Member {
         this.socket.on("getGameSettingsInfo", () => this.requestGameSettingsInfo());
         this.socket.on("getSettingsEnabled", () => this.requestSettingsEnabled());
         this.socket.on("getPoems", () => this.getPoems()); // initial load
+        this.socket.on("getPoemLines", () => this.getPoems()); // initial load
         this.socket.on("leave", () => this.leaveRoom());
 
         // These are all reserved events
@@ -271,7 +278,7 @@ class Member {
     disconnect() {
         // note this could be called by something as simple as closing the tab
         // therefore we don't want to boot someone from the game based on this
-        // however if they are AFK, etc, we should do those things
+        // however if they are AFK, etc., we should do those things
 
         console.log(this.socket.id, "disconnected");
         this.connected = false;
@@ -305,6 +312,12 @@ class Member {
         // crucial method that sends the poem to all users
         // make sure the correct members receive this
         this.io.in(this.roomID).emit("poem", poem);
+    }
+
+    sendPoemAsLines(poemObj: Poem) {
+        // crucial method that sends the poem to all users
+        // make sure the correct members receive this
+        this.io.in(this.roomID).emit("poemLines", Array.from(poemObj.lines));
     }
 
     getPoems() {
@@ -494,9 +507,9 @@ class Editor extends Member {
     currentlyOnLastLine() {
         const thisPoem = this.poemQueue[0];
         if (thisPoem) {
-            const weThinkCurrentLength = thisPoem.lines.length;
-            console.log("we think the poem has ", weThinkCurrentLength, "of", thisPoem.targetLines - 2);
-            return weThinkCurrentLength >= (thisPoem.targetLines - 2);
+            const currentLength = thisPoem.lines.size;
+            console.log("we think the poem has ", currentLength, "of", thisPoem.targetLines - 2);
+            return currentLength >= (thisPoem.targetLines - 2);
         } else {
             return false;
         }
@@ -512,9 +525,9 @@ class Editor extends Member {
             this.lastActivity = Date.now(); // give them some time to type
             this.io.to(this.socket.id).emit("lineEdit", this.poemQueue[0].halfLine);
             const thisPoem = this.poemQueue[0];
-            console.log("we think the poem has", thisPoem.lines.length, "submissions so far");
+            console.log("we think the poem has", thisPoem.lines.size, "submissions so far");
 
-            if (thisPoem.lines.length === (thisPoem.targetLines - 2)) {
+            if (thisPoem.lines.size === (thisPoem.targetLines - 2)) {
                 this.io.to(this.socket.id).emit("lastLine", true);
             } else {
                 this.io.to(this.socket.id).emit("lastLine", false);
@@ -535,9 +548,8 @@ class Editor extends Member {
             return;
         }
 
-        poemToPass.submitLine(firstPart);
+        poemToPass.submitLine(this.deviceID, firstPart, secondPart);
         poemToPass.lineWasEdited(secondPart);
-        poemToPass.halfLine = secondPart;
         // should be a reference!!!
         const nextEditor = thisRoom.editors.get(this.targetEditorID);
         nextEditor.poemQueue.push(poemToPass);
@@ -557,13 +569,17 @@ class Editor extends Member {
         if (isNil(poemToPass)) {
             return;
         }
-        poemToPass.lines.push(lastPart);
+        poemToPass.lines.add({
+            poemID: poemToPass.poemID,
+            lineIndex: poemToPass.lines.size,
+            content: lastPart,
+            authorDevice: this.deviceID,
+            passerDevice: poemToPass.mostRecentEditor,  // previous editor, starts at ""
+            editLength: poemToPass.halfLine.length,     // previous line length, starts at 0
+            addedAt: new Date(),
+        });
 
-        let poemString = "";
-        for (const line of poemToPass.lines) {
-            poemString += line + "\n";
-        }
-        this.handlePoem(poemString);
+        this.handlePoem(poemToPass);
 
         const thisRoom = roomIDToRoom.get(this.roomID);
         thisRoom.nPoemsInRotation--;
@@ -605,7 +621,12 @@ class Editor extends Member {
         }
     }
 
-    handlePoem(poemString: string) {
+    handlePoem(poemObj: Poem) {
+
+        let poemString = "";
+        for (const line of poemObj.lines) {
+            poemString += line.content + "\n";
+        }
 
         const poem: IPoem = {
             content: poemString,
@@ -619,7 +640,9 @@ class Editor extends Member {
         storePoem(poem);
 
         // broadcast the poem to room members via sockets
-        this.sendPoem(poem);
+        // this.sendPoem(poem);
+        // try out the new view
+        this.sendPoemAsLines(poemObj);
 
         // delete the global var from public view
         publicPoems.delete(poem);
@@ -679,13 +702,14 @@ class VIPEditor extends Editor {
 class Poem {
     // represents a single poem
 
-    lines: Array<string>;
-    halfLine: string;
-    poemID: string;
     targetLines: number;
     poemIndex: number;
     io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>;
     roomID: string;
+    poemID: string;
+    halfLine: string;
+    mostRecentEditor: string;
+    lines: Set<ILine>;
 
     // any edit of lines or half-line (e.g. submitLine, handleLineEdit)
     // will send a message to the Spectators in the roomID
@@ -700,14 +724,27 @@ class Poem {
         this.poemIndex = poemIndex;
         this.io = io;
         this.roomID = roomID;
-        this.lines = [];
-        this.halfLine = "";
         this.poemID = uuidv4();
+        this.halfLine = "";
+        this.mostRecentEditor = "";
+        this.lines = new Set<ILine>();
     }
 
-    submitLine(line: string) {
-        this.lines.push(line);
-        this.io.in(this.roomID + "_Spectators").emit("lineSpectator", this.poemIndex, line);
+    submitLine(authorID: string, firstPart: string, secondPart: string) {
+        const myLine = {
+            poemID: this.poemID,
+            lineIndex: this.lines.size,
+            content: firstPart,
+            authorDevice: authorID,
+            passerDevice: this.mostRecentEditor,  // previous editor, starts at ""
+            editLength: this.halfLine.length,     // previous line length, starts at 0
+            addedAt: new Date(),
+        };
+        this.lines.add(myLine);
+        storeLine(myLine);
+        this.mostRecentEditor = authorID;
+        this.halfLine = secondPart;
+        this.io.in(this.roomID + "_Spectators").emit("lineSpectator", this.poemIndex, firstPart);
     }
 
     lineWasEdited(value: string) {
@@ -716,7 +753,7 @@ class Poem {
 
     sendAllLinesTo(socketID: string) {
         // this is used to bring a new spectator up to date
-        this.lines.forEach((line) => this.sendLine(line, socketID));
+        this.lines.forEach((line) => this.sendLine(line.content, socketID));
     }
 
     sendLine(line: string, socketID: string) {

--- a/src/components/LineInput/styles.ts
+++ b/src/components/LineInput/styles.ts
@@ -23,10 +23,6 @@ export const accordionDiv: React.CSSProperties = {
     maxWidth: "60ch",
 };
 
-export const accordionTitle: React.CSSProperties = {
-    margin: "auto",
-};
-
 export const underlineSuggestionDiv: React.CSSProperties = {
     gridColumnStart: 1,
     gridRowStart: 1,

--- a/src/components/Lines/index.tsx
+++ b/src/components/Lines/index.tsx
@@ -9,9 +9,6 @@ const Lines = () => {
     const [ lineEdits, setLineEdits ] = React.useState<Array<string>>([ "", "", "", "" ]);
 
     React.useEffect(() => {
-        // const clearLinesListener = () => {
-        //     setLines([ [], [], [], [] ]);
-        // };
 
         const lineSpectatorListener = (poemIndex: number, line: string) => {
             setLines(prevLines => {
@@ -32,10 +29,7 @@ const Lines = () => {
 
         socket.on("lineSpectator", lineSpectatorListener);
         socket.on("lineEditSpectator", lineEditSpectatorListener);
-        // socket.on("clearLines", clearLinesListener);
 
-        // tells the server for this client to do getLines
-        // since this is client-side, it only happens for this client
         setLines([ [], [], [], [] ]);
         socket.emit("getLines");
 

--- a/src/components/PoemLines/index.tsx
+++ b/src/components/PoemLines/index.tsx
@@ -1,50 +1,12 @@
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import * as React from "react";
-
-import { useSocket } from "../App";
 import {
     poemsBody,
-    poemFont,
-    poemTitle,
 } from "./styles";
-
 import {
     ILine,
-    IPoem,
-    IPoems,
-    IUserTableInfo,
 } from "../../types";
 
-function PoemLines() {
-    const { socket } = useSocket();
-    const [ poemLines, setPoemLines ] = React.useState<ILine[]>([]);
-    const [ editorColors, setEditorColors ] = React.useState<Record<string, string>>({});
-
-    React.useEffect(() => {
-    // Event handlers for the poem and the deletePoem events are set up for the Socket.IO connection.
-        const poemLinesListener = (myPoemLines: ILine[]) => {
-            setPoemLines(myPoemLines);
-        };
-
-        const userTableInfoListener = (info: IUserTableInfo) => {
-            setEditorColors(info.editorColors);
-        };
-
-        socket.on("poemLines", poemLinesListener);
-        socket.on("userTableInfo", userTableInfoListener);
-
-        // socket.emit("getPoemLines");
-        socket.emit("getUserTableInfo"); // initial populate
-
-        return () => {
-            socket.off("poemLines", poemLinesListener);
-            socket.off("userTableInfo", userTableInfoListener);
-        };
-    }, [ socket ]);
-
+function PoemLines({poemLines, editorColors}: {poemLines: ILine[], editorColors: Record<string, string>}) {
     return (
         <div style={poemsBody}>
             {poemLines.map((line) => {

--- a/src/components/PoemLines/index.tsx
+++ b/src/components/PoemLines/index.tsx
@@ -1,0 +1,64 @@
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import * as React from "react";
+
+import { useSocket } from "../App";
+import {
+    poemsBody,
+    poemFont,
+    poemTitle,
+} from "./styles";
+
+import {
+    ILine,
+    IPoem,
+    IPoems,
+    IUserTableInfo,
+} from "../../types";
+
+function PoemLines() {
+    const { socket } = useSocket();
+    const [ poemLines, setPoemLines ] = React.useState<ILine[]>([]);
+    const [ editorColors, setEditorColors ] = React.useState<Record<string, string>>({});
+
+    React.useEffect(() => {
+    // Event handlers for the poem and the deletePoem events are set up for the Socket.IO connection.
+        const poemLinesListener = (myPoemLines: ILine[]) => {
+            setPoemLines(myPoemLines);
+        };
+
+        const userTableInfoListener = (info: IUserTableInfo) => {
+            setEditorColors(info.editorColors);
+        };
+
+        socket.on("poemLines", poemLinesListener);
+        socket.on("userTableInfo", userTableInfoListener);
+
+        // socket.emit("getPoemLines");
+        socket.emit("getUserTableInfo"); // initial populate
+
+        return () => {
+            socket.off("poemLines", poemLinesListener);
+            socket.off("userTableInfo", userTableInfoListener);
+        };
+    }, [ socket ]);
+
+    return (
+        <div style={poemsBody}>
+            {poemLines.map((line) => {
+                return <div key={line.lineIndex} style={{whiteSpace: "pre-line"}}>
+                    <span className={"first-part"} key={line.lineIndex} style={{color: editorColors[line.passerDevice]}}>
+                        {line.content.slice(0, line.editLength)}
+                    </span>
+                    <span className={"second-part"} key={line.lineIndex} style={{color: editorColors[line.authorDevice]}}>
+                        {line.content.slice(line.editLength)}
+                    </span>
+                </div>;
+            })}
+        </div>
+    );
+}
+
+export default PoemLines;

--- a/src/components/PoemLines/styles.ts
+++ b/src/components/PoemLines/styles.ts
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+export const poemsBody: React.CSSProperties = {
+    marginBottom: "2em",
+    marginTop: "auto",
+};
+
+export const poemFont: React.CSSProperties = {
+    lineHeight: "1.5em",
+    whiteSpace: "pre-line",
+};
+
+export const poemTitle: React.CSSProperties = {
+    margin: "auto",
+};

--- a/src/components/Poems/index.tsx
+++ b/src/components/Poems/index.tsx
@@ -20,7 +20,7 @@ function Poems() {
     const { socket } = useSocket();
     // The poems state is a plain object that contains each poem indexed by the poem ID.
     // Using React hooks, this state is updated inside the event handlers to reflect the changes provided by the server.
-    const [ poems, setPoems ] = React.useState<IPoems>({} as IPoems);
+    const [ poems, setPoems ] = React.useState<IPoems>({});
 
     React.useEffect(() => {
     // Event handlers for the poem and the deletePoem events are set up for the Socket.IO connection.

--- a/src/components/PoemsLines/index.tsx
+++ b/src/components/PoemsLines/index.tsx
@@ -1,0 +1,73 @@
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import * as React from "react";
+
+import { useSocket } from "../App";
+import {
+    poemsBody,
+    poemTitle,
+} from "./styles";
+
+import {
+    ILine,
+    IUserTableInfo,
+} from "../../types";
+import PoemLines from "../PoemLines";
+
+function PoemsLines() {
+    const { socket } = useSocket();
+    const [ poemsLines, setPoemsLines ] = React.useState<Array<ILine[]>>([]);
+    const [ editorColors, setEditorColors ] = React.useState<Record<string, string>>({});
+
+    React.useEffect(() => {
+    // Event handlers for the poem and the deletePoem events are set up for the Socket.IO connection.
+        const poemsLinesListener = (myPoemLines: ILine[]) => {
+            setPoemsLines(prevPoemsLines => {
+                return [ ...prevPoemsLines, myPoemLines ];
+            },
+            );
+        };
+
+        const userTableInfoListener = (info: IUserTableInfo) => {
+            setEditorColors(info.editorColors);
+        };
+
+        socket.on("poemLines", poemsLinesListener);
+        socket.on("userTableInfo", userTableInfoListener);
+
+        // socket.emit("getPoemLines");
+        socket.emit("getUserTableInfo"); // initial populate
+
+        return () => {
+            socket.off("poemLines", poemsLinesListener);
+            socket.off("userTableInfo", userTableInfoListener);
+        };
+    }, [ socket ]);
+
+    return (
+        <div className={"poems-with-lines"} style={poemsBody}>
+            {poemsLines.map( (poemLines, poemLinesIndex) => (
+                <div key={poemLinesIndex} className="poem-container">
+                    <Accordion>
+                        <AccordionSummary
+                            expandIcon={<ExpandMoreIcon />}
+                            aria-controls="panel1a-content"
+                            id="panel1a-header"
+                        >
+                            <div style={poemTitle} className={"poem-title"}>
+                                <strong>{"exquisite text #" + poemLinesIndex.toString()}</strong>
+                            </div>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <PoemLines poemLines={poemLines} editorColors={editorColors} />
+                        </AccordionDetails>
+                    </Accordion>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default PoemsLines;

--- a/src/components/PoemsLines/styles.ts
+++ b/src/components/PoemsLines/styles.ts
@@ -4,3 +4,7 @@ export const poemsBody: React.CSSProperties = {
     marginBottom: "2em",
     marginTop: "auto",
 };
+
+export const poemTitle: React.CSSProperties = {
+    margin: "auto",
+};

--- a/src/screens/Game/index.tsx
+++ b/src/screens/Game/index.tsx
@@ -3,7 +3,8 @@ import * as React from "react";
 import GameTransition from "../../components/GameTransition";
 import Leave from "../../components/Leave";
 import LineInput from "../../components/LineInput";
-import Poems from "../../components/Poems";
+// import Poems from "../../components/Poems";
+import PoemLines from "../../components/PoemLines";
 import { gameContainer } from "./styles";
 
 function Game() {
@@ -11,7 +12,8 @@ function Game() {
         <div style={gameContainer} className={"game-container"}>
             <LineInput />
             <Leave />
-            <Poems />
+            <PoemLines />
+            {/*<Poems />*/}
             <GameTransition />
         </div>
     );

--- a/src/screens/Game/index.tsx
+++ b/src/screens/Game/index.tsx
@@ -4,7 +4,7 @@ import GameTransition from "../../components/GameTransition";
 import Leave from "../../components/Leave";
 import LineInput from "../../components/LineInput";
 // import Poems from "../../components/Poems";
-import PoemLines from "../../components/PoemLines";
+import PoemsLines from "../../components/PoemsLines";
 import { gameContainer } from "./styles";
 
 function Game() {
@@ -12,7 +12,7 @@ function Game() {
         <div style={gameContainer} className={"game-container"}>
             <LineInput />
             <Leave />
-            <PoemLines />
+            <PoemsLines />
             {/*<Poems />*/}
             <GameTransition />
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export enum LineLength {
 export interface IUserTableInfo {
     editors: Array<string>;
     spectators: Array<string>;
+    editorColors: Record<string, string>;
 }
 
 export interface IGameSettingsInfo {
@@ -31,12 +32,12 @@ export interface IUserInfo {
     turnsAway: number;
 }
 
-export interface ILine {
-    id: Key;
-    user: IUserInfo;
-    value: string;
-    createdAt: Date;
-}
+// export interface ILine {
+//     id: Key;
+//     user: IUserInfo;
+//     value: string;
+//     createdAt: Date;
+// }
 
 export interface IPoems {
     [id: string]: IPoem;
@@ -49,15 +50,26 @@ export interface IPoem {
     title: string;
 }
 
+export interface ILine {
+    poemID: string;
+    lineIndex: number;
+    content: string;
+    authorDevice: string;
+    passerDevice: string;
+    editLength: number;
+    addedAt: Date;
+}
+
 export interface IObjectStringToString {
     [key: string]: string;
 }
 
 export interface ServerToClientEvents {
-    line: (a: ILine) => void;
+    // line: (a: ILine) => void;
     lineEdit: (a: string) => void;
     lineEditSize: (a: number, b: number) => void;
     poem: (a: IPoem) => void;
+    poemLines: (a: ILine[]) => void;
 
     joinError: (a: string) => void;
     joinSuccess: () => void;
@@ -80,7 +92,7 @@ export interface ClientToServerEvents {
     poemDone: () => void;
     getLines: () => void;
     getPoems: () => void;
-
+    getPoemLines: () => void;
     recognizeDevice: (a: string) => void;
     createGameHost: (a: string) => void;
     joinGameAs: (a: string, b: string, c: string) => void;


### PR DESCRIPTION
A goal we have had for a long time is to keep track of the contributions of each editor separately - that is, keep track of each snippet of poetry (usually 1 line, except in the case of the first and last lines which are 1.5 lines). To do so, it would be nice to store the lines separately, both in memory and on the database. This allows you to visualize the poem as a collection of lines made by different contributors, who are displayed in different colors.

For each poem, for each line, store:
1) The identity of the editor (deviceID, which can be "saved.")
2) The editor that passed the poem just before this was written (null in the case of the first line).
3) The character length of the inherited lineEdit.

This allows us to determine the set of editors for a poem and allows us to color-code the Poem based on editors.