### PR TITLE
chore: room self-destruct, refactor, server constants

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,13 @@ module.exports = {
         "@typescript-eslint",
     ],
     "rules": {
+        "sort-imports": [ "error", {
+            "ignoreCase": false,
+            "ignoreDeclarationSort": true,
+            "ignoreMemberSort": false,
+            "memberSyntaxSortOrder": [ "none", "all", "multiple", "single" ],
+            "allowSeparatedGroups": false,
+        } ],
         "array-bracket-spacing": [
             "error",
             "always",

--- a/server/package.json
+++ b/server/package.json
@@ -35,6 +35,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "nodemon --watch './**/*.ts' --exec ts-node start.ts"
+    "startwatch": "nodemon --watch './**/*.ts' --exec ts-node start.ts",
+    "start": "ts-node start.ts"
   }
 }

--- a/server/queries.ts
+++ b/server/queries.ts
@@ -1,11 +1,11 @@
 import {
-    pgSequelConn,
     Poem,
+    pgSequelConn,
 } from "./entity/poem";
 import {
     Line,
 } from "./entity/line";
-import { IPoem, ILine } from "../src/types";
+import { ILine, IPoem } from "../src/types";
 
 (async () => {
     try {

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -13,25 +13,25 @@ import {
     ClientToServerEvents,
     IGameSettingsInfo,
     ILine,
-    InterServerEvents,
     IPoem,
+    InterServerEvents,
     ServerToClientEvents,
     SocketData,
 } from "../src/types";
 import {
     returnPoems,
-    storePoem,
     storeLine,
+    storePoem,
 } from "./queries";
 import {
-    lineSepString,
-    retrieveNPoemsAtStart,
-    maxEditors,
+    checkActivityInterval,
     defaultGameSettings,
+    editorColorArr,
+    lineSepString,
+    maxEditors,
     maxMemberTimeSpentInactive,
     maxRoomTimeSpentEmpty,
-    checkActivityInterval,
-    editorColorArr,
+    retrieveNPoemsAtStart,
 } from "../src/constants";
 
 // this function grabs some old poems to have something to show the users
@@ -165,10 +165,14 @@ class Room {
     checkActivity() {
         const currentTime = Date.now();
         console.log(this.roomID, "checking activity at", currentTime);
-        if (this.editors.size === 0 && this.spectators.size === 0 &&
-            (currentTime - this.createdAt) > maxRoomTimeSpentEmpty) {
+        if (
+            this.editors.size === 0
+            && this.spectators.size === 0
+            && (currentTime - this.createdAt) > maxRoomTimeSpentEmpty
+        ) {
             console.log(this.roomID, "spent too long with no members, destroying");
             this.selfDestruct();
+            return;
         }
         for (const thisSpectator of this.spectators.values()) {
             if (!thisSpectator.connected && (currentTime - thisSpectator.lastActivity) > maxMemberTimeSpentInactive) {
@@ -435,17 +439,25 @@ class Editor extends Member {
         const thisRoom = roomIDToRoom.get(this.roomID);
         thisRoom.removeEditor(this.deviceID);
 
-        // hand off any poems in your queue to the next person
-        if (thisRoom.gameOngoing) {
-            const nextEditor = thisRoom.editors.get(this.targetEditorID);
-            nextEditor.poemQueue.push(...this.poemQueue);
-            if (!nextEditor.isCurrentlyEditing) {
-                nextEditor.possibleStartNewTurn();
+        if (thisRoom.gameOngoing) {  // hand off any poems in your queue to the next person
+            if (thisRoom.editors.size > 0) {
+                const nextEditor = thisRoom.editors.get(this.targetEditorID);
+                nextEditor.poemQueue.push(...this.poemQueue);
+                if (!nextEditor.isCurrentlyEditing) {
+                    nextEditor.possibleStartNewTurn();
+                }
+                // trigger the room to reorganize the editors
+                thisRoom.reorganizeEditors();
+            } else {
+                console.log("there are no editors left after the game started, no way to continue.");
+                thisRoom.selfDestruct();
+            }
+        } else {  // if we are still in the lobby then tell first editor to check whether they are VIP
+            const firstEditor = thisRoom.editors.values().next().value;
+            if (!isNil(firstEditor)) {
+                firstEditor.requestSettingsEnabled();
             }
         }
-
-        // trigger the room to reorganize the editors
-        thisRoom.reorganizeEditors();
     }
 
     // setSend
@@ -460,6 +472,8 @@ class Editor extends Member {
         this.socket.on("passTurn", (firstPart, secondPart) => this.handlePassTurn(firstPart, secondPart));
         this.socket.on("lastLine", (value) => this.handleLastLine(value)); // whenever a new line has been submitted into the poem.
         this.socket.on("getLastLineStatus", () => this.requestLastLineStatus());
+        this.socket.on("alterGameSettings", (value) => this.alterGameSettings(value));
+        this.socket.on("startGame", () => this.broadcastStartGame());
     }
 
     unsetReceive() {
@@ -470,6 +484,8 @@ class Editor extends Member {
         this.socket.removeAllListeners("passTurn");
         this.socket.removeAllListeners("lastLine");
         this.socket.removeAllListeners("getLastLineStatus");
+        this.socket.removeAllListeners("alterGameSettings");
+        this.socket.removeAllListeners("startGame");
     }
 
     requestLineEdit() {
@@ -656,39 +672,6 @@ class Editor extends Member {
         // delete the global var from public view
         publicPoems.delete(poem);
     }
-}
-
-class VIPEditor extends Editor {
-    joinRoom() {
-        super.joinRoom();
-        this.socket.join(this.roomID + "_VIP");
-    }
-
-    leaveRoom() {
-        // super.leaveRoom();
-        // this.socket.leave(this.roomID + "_VIP");
-        //
-        // // should make the next editor in line become VIP...
-        // const thisRoom = roomIDToRoom.get(this.roomID);
-        // const nextEditor = thisRoom.editors.get(this.targetEditorID);
-        // nextEditor.becomeVIP();  // or something
-
-        // TODO: implement VIP leaves the room
-        // only tricky if we are still in the lobby...
-        console.log("Having the VIP leave the room is not implemented yet.");
-    }
-
-    setReceive() {
-        super.setReceive();
-        this.socket.on("alterGameSettings", (value) => this.alterGameSettings(value));
-        this.socket.on("startGame", () => this.broadcastStartGame());
-    }
-
-    unsetReceive() {
-        super.unsetReceive();
-        this.socket.removeAllListeners("alterGameSettings");
-        this.socket.removeAllListeners("startGame");
-    }
 
     alterGameSettings(gameSettings: IGameSettingsInfo) {
         console.log("alterGameSettings");
@@ -704,7 +687,12 @@ class VIPEditor extends Editor {
 
     requestSettingsEnabled() {
         console.log(this.name, "requestSettingsEnabled");
-        this.io.to(this.socket.id).emit("gameSettingsEnabled", true);
+        this.io.to(this.socket.id).emit("gameSettingsEnabled", this.isVIP());
+    }
+
+    isVIP() {
+        const thisRoom = roomIDToRoom.get(this.roomID);
+        return thisRoom.editors.keys().next().value === this.deviceID;
     }
 }
 
@@ -849,10 +837,7 @@ function sockets(io: Server<ClientToServerEvents, ServerToClientEvents, InterSer
                     return;
                 }
                 deviceIDToRoomID[deviceID] = roomID;
-                const useEditorClass = (targetRoom.editors.size === 0
-                    ? VIPEditor
-                    : Editor);
-                const thisEditor = new useEditorClass(io, socket, roomID, deviceID, name);
+                const thisEditor = new Editor(io, socket, roomID, deviceID, name);
                 thisEditor.joinRoom();
                 io.to(socket.id).emit("navigate", "/lobby");
                 targetRoom.addEditor(deviceID, thisEditor);

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -14,9 +14,7 @@ import {
     IGameSettingsInfo,
     ILine,
     InterServerEvents,
-    IObjectStringToString,
     IPoem,
-    LineLength,
     ServerToClientEvents,
     SocketData,
 } from "../src/types";
@@ -25,18 +23,16 @@ import {
     storePoem,
     storeLine,
 } from "./queries";
-import { lineSepString } from "../src/constants";
-
-const retrieveNPoemsAtStart = 1;
-const maxEditors = 4;
-const defaultGameSettings: IGameSettingsInfo = {
-    lineLength: LineLength.short,
-    nPoems: 1,
-    nRounds: 2,
-};
-const activityTimeout = 180000; // ms
-const checkActivityInterval = 30000; // ms
-const editorColorArr = [ "#4F71BE", "#B86029", "#A9D18E", "#B89230" ];
+import {
+    lineSepString,
+    retrieveNPoemsAtStart,
+    maxEditors,
+    defaultGameSettings,
+    maxMemberTimeSpentInactive,
+    maxRoomTimeSpentEmpty,
+    checkActivityInterval,
+    editorColorArr,
+} from "../src/constants";
 
 // this function grabs some old poems to have something to show the users
 async function populatePoems() {
@@ -53,9 +49,9 @@ async function populatePoems() {
 populatePoems();
 
 // New global data structures
-const socketIDToDeviceID: IObjectStringToString = {};
-const deviceIDToSocketID: IObjectStringToString = {};  // unique on device. only latest is present
-const deviceIDToRoomID: IObjectStringToString = {};
+const socketIDToDeviceID: Record<string, string> = {};
+const deviceIDToSocketID: Record<string, string> = {};  // unique on device. only latest is present
+const deviceIDToRoomID: Record<string, string> = {};
 const roomIDToRoom: Map<string, any> = new Map();
 const roomIDToHost: Map<string, Host> = new Map();
 const publicPoems: Set<IPoem> = new Set();
@@ -72,6 +68,7 @@ class Room {
     gameOngoing: boolean;
     nPoemsInRotation: number;
     activityInterval: ReturnType<typeof setInterval>;
+    createdAt: number;
 
     constructor(
         io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
@@ -90,6 +87,7 @@ class Room {
 
         // check user activity every 30 seconds
         this.activityInterval = setInterval(this.checkActivity.bind(this), checkActivityInterval);
+        this.createdAt = Date.now();
     }
 
     addEditor(deviceUUID: string, editorObj: Editor) {
@@ -167,18 +165,30 @@ class Room {
     checkActivity() {
         const currentTime = Date.now();
         console.log(this.roomID, "checking activity at", currentTime);
+        if (this.editors.size === 0 && this.spectators.size === 0 &&
+            (currentTime - this.createdAt) > maxRoomTimeSpentEmpty) {
+            console.log(this.roomID, "spent too long with no members, destroying");
+            this.selfDestruct();
+        }
         for (const thisSpectator of this.spectators.values()) {
-            if (!thisSpectator.connected && (currentTime - thisSpectator.lastActivity) > activityTimeout) {
+            if (!thisSpectator.connected && (currentTime - thisSpectator.lastActivity) > maxMemberTimeSpentInactive) {
                 thisSpectator.leaveRoom();
                 console.log("booting", thisSpectator.name, "based on inactivity");
             }
         }
         for (const thisEditor of this.editors.values()) {
-            if (thisEditor.isCurrentlyEditing && ((currentTime - thisEditor.lastActivity) > activityTimeout)) {
+            if (thisEditor.isCurrentlyEditing && ((currentTime - thisEditor.lastActivity) > maxMemberTimeSpentInactive)) {
                 thisEditor.leaveRoom();
                 console.log("booting", thisEditor.name, "based on inactivity");
             }
         }
+    }
+
+    selfDestruct() {
+        console.log(this.roomID, "self-destructing");
+        clearInterval(this.activityInterval);
+        roomIDToHost.delete(this.roomID);
+        roomIDToRoom.delete(this.roomID);
     }
 }
 
@@ -611,9 +621,7 @@ class Editor extends Member {
                 delete deviceIDToSocketID[spectatorID];
                 thisRoom.spectators.delete(spectatorID);
             }
-            clearInterval(thisRoom.activityInterval);
-            roomIDToHost.delete(this.roomID);
-            roomIDToRoom.delete(this.roomID);
+            thisRoom.selfDestruct();
             // console.log("deviceIDToRoomID", deviceIDToRoomID);
             // console.log("roomIDToHost", roomIDToHost);
             // console.log("roomIDToRoom", roomIDToRoom);

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -5,16 +5,16 @@ import {
     useOutletContext,
 } from "react-router-dom";
 import {
-    io,
     Socket,
+    io,
 } from "socket.io-client";
 import { v4 as uuidv4 } from "uuid";
 
 import Tutorial from "../Tutorial";
 import {
+    app,
     appHeader,
     appTitle,
-    app,
     possibleSocket,
 } from "./styles";
 

--- a/src/components/GameSettings/index.tsx
+++ b/src/components/GameSettings/index.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
-import { useSocket } from "../App";
-import { IGameSettingsInfo, LineLength } from "../../types";
+import * as React from "react";
+
 import { defaultGameSettings } from "../../constants";
+import { useSocket } from "../App";
+
+import { IGameSettingsInfo, LineLength } from "../../types";
 
 function GameSettings() {
     const { socket } = useSocket();

--- a/src/components/GameSettings/index.tsx
+++ b/src/components/GameSettings/index.tsx
@@ -1,20 +1,19 @@
+import * as React from "react";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
-import * as React from "react";
-
 import { useSocket } from "../App";
-
 import { IGameSettingsInfo, LineLength } from "../../types";
+import { defaultGameSettings } from "../../constants";
 
 function GameSettings() {
     const { socket } = useSocket();
 
     const [ settingsEnabled, setSettingsEnabled ] = React.useState<boolean>(false);
-    const [ lineLength, setLineLength ] = React.useState<LineLength>(LineLength.short);
-    const [ nRounds, setNRounds ] = React.useState<number>(2);
-    const [ nPoems, setNPoems ] = React.useState<number>(1);
+    const [ lineLength, setLineLength ] = React.useState<LineLength>(defaultGameSettings.lineLength);
+    const [ nRounds, setNRounds ] = React.useState<number>(defaultGameSettings.nRounds);
+    const [ nPoems, setNPoems ] = React.useState<number>(defaultGameSettings.nPoems);
 
     // these will only ever take place for the VIP editor
     const handleLineLength = (event: React.MouseEvent<HTMLElement>, newLineLength: LineLength) => {

--- a/src/components/Leave/index.tsx
+++ b/src/components/Leave/index.tsx
@@ -7,7 +7,7 @@ import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import Box from "@mui/material/Box";
 import { ClickAwayListener } from "@mui/material";
-import { leaveFAB, leaveConfirmBox } from "./styles";
+import { leaveConfirmBox, leaveFAB } from "./styles";
 
 function Leave() {
     const { socket } = useSocket();

--- a/src/components/LineInput/index.tsx
+++ b/src/components/LineInput/index.tsx
@@ -14,14 +14,16 @@ import {
     LineLength,
 } from "../../types";
 import {
-    lineSepString,
     lineConstraints,
+    lineSepString,
 } from "../../constants";
 import { shortDur } from "../../constants";
 import { useStateRef } from "../../helpers";
 import {
     activeInput,
     caret,
+    completeConfirmBox,
+    completeFAB,
     errorMessage,
     helpMessageStyle,
     inactiveInput,
@@ -35,8 +37,6 @@ import {
     underlineSpan,
     underlineSpanHover,
     underlineSuggestionDiv,
-    completeConfirmBox,
-    completeFAB,
 } from "./styles";
 import "./LineInput.css";
 

--- a/src/components/PoemsLines/index.tsx
+++ b/src/components/PoemsLines/index.tsx
@@ -10,15 +10,15 @@ import { CopyToClipboard } from "react-copy-to-clipboard";
 import { useSocket } from "../App";
 import PoemLines from "../PoemLines";
 import {
-    poemsBody,
     poemTitle,
+    poemsBody,
 } from "./styles";
 
 import {
     ILine,
     IUserTableInfo,
 } from "../../types";
-import { shortDur, lineSepString } from "../../constants";
+import { lineSepString, shortDur } from "../../constants";
 
 function PoemsLines() {
     const { socket } = useSocket();

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,8 @@
-import { ILineConstraintDict } from "../types";
+import {
+    IGameSettingsInfo,
+    ILineConstraintDict,
+    LineLength,
+} from "../types";
 
 export const roomCodeLength = 4;
 export const maxNameChars = 13;
@@ -29,3 +33,22 @@ export const lineConstraints: ILineConstraintDict = {
         idealCharsOnLineTwo: 20,
     },
 };
+
+// server constants
+
+export const retrieveNPoemsAtStart = 1;
+export const maxEditors = 4;
+export const defaultGameSettings: IGameSettingsInfo = {
+    lineLength: LineLength.short,
+    nPoems: 1,
+    nRounds: 2,
+};
+export const maxMemberTimeSpentInactive = 180000; // ms
+export const maxRoomTimeSpentEmpty = 300000; // ms
+export const checkActivityInterval = 30000; // ms
+export const editorColorArr = [
+    "#4F71BE",
+    "#B86029",
+    "#A9D18E",
+    "#B89230",
+];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import ReactDOM from "react-dom/client";
 import {
     BrowserRouter,
-    Routes,
     Route,
+    Routes,
 } from "react-router-dom";
 
 import "./index.css";

--- a/src/screens/Join/index.tsx
+++ b/src/screens/Join/index.tsx
@@ -6,7 +6,7 @@ import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import { useSocket } from "../../components/App";
 import CreateGame from "../../components/CreateGame";
-import { shortDur, roomCodeLength, maxNameChars } from "../../constants";
+import { maxNameChars, roomCodeLength, shortDur } from "../../constants";
 
 export default function Join() {
     const navigate = useNavigate();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,10 +73,6 @@ export interface ILine {
     addedAt: Date;
 }
 
-export interface IObjectStringToString {
-    [key: string]: string;
-}
-
 export interface ServerToClientEvents {
     // line: (a: ILine) => void;
     lineEdit: (a: string) => void;


### PR DESCRIPTION
Prior to this, if a room never had members join and complete a poem, it would live forever on the server.

After this, the room has 5 minutes (defined constant) to gain a single member before it automatically self-destructs. This prevents long-term memory leak on the server. The code also functions in such a way that if everyone were to be kicked due to inactivity (e.g. abandoned game), the room would self-destruct. But until we figure out how to safely remove the VIP from the game, this can't happen yet.

In doing this, I decided to move constants in the server to the main constants file in src/constants/index.ts and do some refactoring, like for example LineInput inherits its default values correctly from the constants file.

Also, I changed "yarn start" to just start the server without using nodemon because our server code doesn't seem (to me) to be set up to allow for us to actually benefit from automatic restarts while editing and debugging. I'd be happy to find out how it can be used. And if you really want to run the server with the nodemon watcher, use "yarn startwatch".