### PR TITLE
feat: visualize editors in lobby as graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^18.2.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
+    "react-graph-vis": "^1.0.7",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "sequelize": "^6.21.3",
@@ -36,6 +37,8 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4",
     "uuid": "^8.3.2",
+    "vis-data": "^7.1.4",
+    "vis-network": "^9.1.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/UserGraph/index.tsx
+++ b/src/components/UserGraph/index.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import Graph from "react-graph-vis";
+
+import { useSocket } from "../App";
+import { IGraph, IUserTableInfo } from "../../types";
+import { editorColorArr } from "../../constants";
+
+function UserGraph() {
+    const options = {
+        width: "300px",
+        height: "300px",
+        clickToUse: true,
+        layout: {
+            hierarchical: false,
+        },
+        edges: {
+            color: "#000000",
+            smooth: true,
+        },
+        interaction: {
+            hover: true,
+        },
+    };
+
+    const { socket } = useSocket();
+
+    const [ spectatorArr, setSpectatorArr ] = React.useState<Array<string>>([]);
+
+    const [ graph, setGraph ] = React.useState<IGraph>({
+        nodes: [],
+        edges: [],
+    });
+
+    // listen for arrays of editors and spectators
+    React.useEffect(() => {
+
+        // Event handlers for the line and the deleteLine events are set up for the Socket.IO connection.
+        const userTableInfoListener = (info: IUserTableInfo) => {
+            const nEditors = info["editors"].length;
+            setGraph({
+                nodes: info["editors"].map((name, nameIndex) => (
+                    {   "id": nameIndex,
+                        "label": name,
+                        "color": editorColorArr[nameIndex] }
+                )),
+                edges: [ ...Array(nEditors).keys() ].map((v) => ({ "from": v, "to": (v + 1) % nEditors })),
+            });
+            setSpectatorArr(info["spectators"]);
+        };
+
+        socket.on("userTableInfo", userTableInfoListener);
+        socket.emit("getUserTableInfo"); // initial populate
+
+        return () => {
+            socket.off("userTableInfo", userTableInfoListener);
+        };
+    }, [ socket ]);
+
+    return (
+        <React.Fragment>
+            <div className={"userGraph"} style={{ display: "flex", justifyContent: "center" }}>
+                <Graph graph={graph} options={options} style={{ height: "300px" }} />
+            </div>
+            <div className={"spectators"} style={{ textAlign: "center" }}>
+                <h2>Spectators:</h2>
+                {spectatorArr.map((name, nameIndex) => {
+                    return (
+                        <p key={nameIndex}>{name}</p>
+                    );
+                })}
+            </div>
+        </React.Fragment>
+    );
+}
+
+export default UserGraph;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,7 +11,7 @@ export const FABSpace = 10;
 export const FABDiameter = 40;
 export const headerHeight = 60;
 
-export const shortDur = 3000;
+export const shortDur = 3000; // ms
 
 export const lineSepString = "\n";
 
@@ -43,12 +43,12 @@ export const defaultGameSettings: IGameSettingsInfo = {
     nPoems: 1,
     nRounds: 2,
 };
-export const maxMemberTimeSpentInactive = 180000; // ms
-export const maxRoomTimeSpentEmpty = 300000; // ms
-export const checkActivityInterval = 30000; // ms
+export const maxMemberTimeSpentInactive = 18000000; // ms
+export const maxRoomTimeSpentEmpty = 30000000; // ms
+export const checkActivityInterval = 3000000; // ms
 export const editorColorArr = [
-    "#4F71BE",
     "#B86029",
-    "#A9D18E",
+    "#4F71BE",
+    "#89BA4E",
     "#B89230",
 ];

--- a/src/screens/Lobby/index.tsx
+++ b/src/screens/Lobby/index.tsx
@@ -3,12 +3,14 @@ import * as React from "react";
 import GameSettings from "../../components/GameSettings";
 import GameTransition from "../../components/GameTransition";
 import Leave from "../../components/Leave";
-import UserTable from "../../components/UserTable";
+import UserGraph from "../../components/UserGraph";
+// import UserTable from "../../components/UserTable";
 
 function Lobby() {
     return (
         <div >
-            <UserTable />
+            {/*<UserTable />*/}
+            <UserGraph />
             <GameSettings />
             <Leave />
             <GameTransition />

--- a/src/types/@custom_types/index.d.ts
+++ b/src/types/@custom_types/index.d.ts
@@ -1,0 +1,32 @@
+declare module "react-graph-vis" {
+    import { Data, DataSet, Edge, Network, NetworkEvents, Node, Options } from "vis";
+    import { Component } from "react";
+
+    export { Network, NetworkEvents, Options, Node, Edge, DataSet, Data } from "vis";
+
+    export type GraphEvents = {
+        [event in NetworkEvents]?: (params?: any) => void;
+    };
+
+    export interface NetworkGraphProps {
+        graph: Data;
+        options?: Options;
+        events?: GraphEvents;
+        getNetwork?: (network: Network) => void;
+        identifier?: string;
+        style?: React.CSSProperties;
+        getNodes?: (nodes: DataSet<Node>) => void;
+        getEdges?: (edges: DataSet<Edge>) => void;
+    }
+
+    export interface NetworkGraphState {
+        identifier: string;
+    }
+
+    export default class NetworkGraph extends Component<
+        NetworkGraphProps,
+        NetworkGraphState
+        > {
+        render();
+    }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,22 @@ export enum LineLength {
     long = "long",
 }
 
+export interface INode {
+    id: number,
+    label: string,
+    color: string,
+}
+
+export interface IEdge {
+    from: number,
+    to: number,
+}
+
+export interface IGraph {
+    nodes: INode[],
+    edges: IEdge[],
+}
+
 export interface ILineConstraints {
     minCharsOnLineOne: number;
     maxCharsOnLineOne: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "*": ["src/types/@custom_types/*"],
+    }
   },
   "include": [
     "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7770,7 +7770,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7910,6 +7910,17 @@ react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+
+react-graph-vis@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/react-graph-vis/-/react-graph-vis-1.0.7.tgz#55b934100c5235e7cc0e8721646c21246e4b7d75"
+  integrity sha512-FI35zlBMKU22JEvG1ukd1DDwW185y4YrDvHm6Bom9EGdA+UNMrZrIV/lyPIRWPcRkzbKaA1w1NvOYcRApD4KdQ==
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.10"
+    uuid "^2.0.1"
+    vis-data "^7.1.2"
+    vis-network "^9.0.0"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -9287,6 +9298,11 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
+  integrity sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
@@ -9320,6 +9336,16 @@ vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+vis-data@^7.1.2, vis-data@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/vis-data/-/vis-data-7.1.4.tgz#90e5e796a79e1901de14c0808fb32a1a0735c1dc"
+  integrity sha512-usy+ePX1XnArNvJ5BavQod7YRuGQE1pjFl+pu7IS6rCom2EBoG0o1ZzCqf3l5US6MW51kYkLR+efxRbnjxNl7w==
+
+vis-network@^9.0.0, vis-network@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/vis-network/-/vis-network-9.1.2.tgz#ddaca300a9764bbf1646a0aa03eb28fe55823ca8"
+  integrity sha512-BdapguKg7sk3NvdZaDsM7T6rNhOBFz0/F4ZScxctK4klRzQPLQPTEcmbioXaZhMkkgWymzBR3lFCxL1q+eYyAw==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
TBH this is one of the stupider pull requests I have made. Get a load of this.

Prior to this, the lobby view was pretty boring. I wanted to try out one potential way that the editor rotation could be visualized. Namely, with a mathematical graph, via the vis-network library. What's supposed to be cool about this is that the visualization of the graph has bouncy physics and you can play with it.

I tried it and the performance seemed like it really, really sucked. I was curious whether your experience is the same, and whether you think it's an interesting idea.

If you think it's a potentially interesting idea, I think I could try to optimize the performance by tweaking the visualization parameters. For example it probably doesn't need to scroll, it doesn't really need physics, and clicking on the nodes/edges doesn't need to do anything.

This requires THREE dependencies (vis-network, vis-data, and react-graph-vis) so make sure you install them if you want to check this out.