### PR TITLE
fix: hide inactive-input spacer asterisks in dark mode and prevent en…

### DIFF
--- a/src/components/LineInput/styles.ts
+++ b/src/components/LineInput/styles.ts
@@ -70,7 +70,7 @@ export const spacingSpan: React.CSSProperties = {
 };
 
 export const textSpacer: React.CSSProperties = {
-    color: "transparent",
+    color: "white",
     margin: "auto",
     textAlign: "center",
     whiteSpace: "pre",

--- a/src/components/LineInput/styles.ts
+++ b/src/components/LineInput/styles.ts
@@ -70,7 +70,7 @@ export const spacingSpan: React.CSSProperties = {
 };
 
 export const textSpacer: React.CSSProperties = {
-    color: "white",
+    color: "transparent",
     margin: "auto",
     textAlign: "center",
     whiteSpace: "pre",

--- a/src/components/TypewriterPoem/TypewriterPoem.tsx
+++ b/src/components/TypewriterPoem/TypewriterPoem.tsx
@@ -160,7 +160,7 @@ export default function TypewriterPoem({
             style={{
                 ...poemTypography,
                 whiteSpace: "pre-line",
-                height: `${nLines + 4}em`,
+                minHeight: `${nLines + 4}em`,
                 width: `${width}px`,
                 textAlign: "left",
             }}

--- a/src/context/SocketListeners.ts
+++ b/src/context/SocketListeners.ts
@@ -78,6 +78,9 @@ export const socketListeners = ({
         setLines((prevLines) =>
             updateAtIndex(prevLines, collaborationIndex, [...prevLines[collaborationIndex], content]),
         );
+        // a line just completed — clear the active-editor typing buffer so stale
+        // asterisks from the previous editor don't show until the next editor starts typing
+        setPoemInputSpectate("");
     };
 
     const receivePanelSpectator = (collaborationIndex: number, content: IPanel["content"]) => {


### PR DESCRIPTION
…d-screen poem clipping

## Purpose

1) I can see asterisks in between rounds on poetry.
2) The end screen cuts off the bottom of the poem.

## Changes

- textSpacer in LineInput/styles.ts: color: white -> transparent so the layout-spacer asterisks (used while another player is typing) stay invisible regardless of theme](fix: clear inter-round spectate buffer to hide stale asterisks; widen typewriter container to prevent end-screen poem clipping)
- TypewriterPoem: height -> minHeight so when real line wrapping exceeds the nLines + 4em estimate, the container grows instead of letting the color-legend card render over the last lines of the poem

## Testing

- Start dev server and front end
- Create poem room
- Test long and short poems
- Review end screen for clipping

- also two player asterisks