### PR TITLE
fix: gate bot feature server-side so secret name is never sent to the front-end

### DIFF
--- a/server/modules/editor.ts
+++ b/server/modules/editor.ts
@@ -98,6 +98,7 @@ class Editor extends Member {
     setReceive() {
         super.setReceive();
         this.listen("ctsRequestEditorActive", () => this.sendActivity());
+        this.listen("ctsRequestBotEnabled", () => this.sendBotEnabled());
         this.listen("ctsStartGame", () => this.broadcastStartGame());
         this.listen("ctsAlterGameSettings", (value) => this.alterGameSettings(value));
     }
@@ -105,6 +106,19 @@ class Editor extends Member {
     sendActivity() {
         logger.debug(`${this.name} requestEditorActivity`);
         this.emitToSelf("stcEditorActive", this.hasWorkInQueue());
+    }
+
+    // Whether THIS editor is allowed to add a bot. The authorized name lives
+    // only in the server env, so the client gates its "Add Bot" button on this
+    // flag and never learns the secret name. The add-bot handlers re-check the
+    // same condition, so this is presentation-only, not the security boundary.
+    isBotAuthorized() {
+        return Boolean(process.env.AUTHORIZED_BOT_USER_NAME) && this.name === process.env.AUTHORIZED_BOT_USER_NAME;
+    }
+
+    sendBotEnabled() {
+        logger.debug(`${this.name} requestBotEnabled`);
+        this.emitToSelf("stcBotEnabled", this.isBotAuthorized());
     }
 
     hasWorkInQueue() {
@@ -158,7 +172,7 @@ export class PoemEditor extends Editor {
 
     requestAddPoemBotToRoom() {
         logger.debug("ctsAddPoemBot");
-        if (this.name !== process.env.AUTHORIZED_BOT_USER_NAME) {
+        if (!this.isBotAuthorized()) {
             logger.warn(`Unauthorized attempt to add poem bot to the room from user ${this.name}`);
             return;
         }
@@ -398,7 +412,7 @@ export class DrawingEditor extends Editor {
 
     requestAddDrawingBotToRoom() {
         logger.debug("ctsAddDrawingBot");
-        if (this.name !== process.env.AUTHORIZED_BOT_USER_NAME) {
+        if (!this.isBotAuthorized()) {
             logger.warn(`Unauthorized attempt to add drawing bot to the room from user ${this.name}`);
             return;
         }

--- a/src/components/SocketHandler/SocketHandler.tsx
+++ b/src/components/SocketHandler/SocketHandler.tsx
@@ -35,6 +35,7 @@ export default function SocketHandler({ children }: Props) {
     const [joinErrorMessage, setJoinErrorMessage] = React.useState<string>("");
     const [roomCode, setRoomCode] = React.useState<string>("");
     const [settingsEnabled, setSettingsEnabled] = React.useState<boolean>(false);
+    const [botEnabled, setBotEnabled] = React.useState<boolean>(false);
     const [lineLength, setLineLength] = React.useState<LineLength>(LineLength.SHORT);
     const [nRounds, setNRounds] = React.useState<number>(defaultGameSettings.nRounds);
     const [nPoems, setNPoems] = React.useState<number>(defaultGameSettings.nPoems);
@@ -62,6 +63,7 @@ export default function SocketHandler({ children }: Props) {
                 setJoinErrorMessage,
                 setRoomCode,
                 setSettingsEnabled,
+                setBotEnabled,
                 setLineLength,
                 setNRounds,
                 setNPoems,
@@ -92,6 +94,8 @@ export default function SocketHandler({ children }: Props) {
                 setRoomCode,
                 setEditorActive,
                 settingsEnabled,
+                botEnabled,
+                setBotEnabled,
                 lineLength,
                 nRounds,
                 nPoems,

--- a/src/components/UserTable/UserTable.tsx
+++ b/src/components/UserTable/UserTable.tsx
@@ -5,10 +5,8 @@ import { textCentered } from "styles/common";
 import { Medium } from "types/types";
 import { logger } from "utilities/loggerUtils";
 
-const SECRET_NAME = "SANANBYEKIM";
-
 function UserTable() {
-    const { userInfo, settingsEnabled, medium } = useSocketInfo();
+    const { userInfo, settingsEnabled, botEnabled, medium } = useSocketInfo();
     logger.debug(`userInfo ${userInfo}`);
     if (!userInfo) {
         return null;
@@ -24,8 +22,10 @@ function UserTable() {
         return null;
     }
 
-    const isHostSecret = editors.length > 0 && editors[0] === SECRET_NAME;
-    const showAddBot = isHostSecret && (medium === Medium.POETRY || medium === Medium.DRAWING);
+    // The server tells us whether this client may add a bot (it checks the
+    // authorized name server-side), so the secret name is never shipped to the
+    // front-end. The add-bot handlers re-check authorization server-side too.
+    const showAddBot = Boolean(botEnabled) && (medium === Medium.POETRY || medium === Medium.DRAWING);
     const addBot = medium === Medium.DRAWING ? emitAddDrawingBot : emitAddPoemBot;
 
     return (

--- a/src/context/SocketInfoProvider.tsx
+++ b/src/context/SocketInfoProvider.tsx
@@ -8,6 +8,8 @@ export const SocketInfoContext = createContext<ISocketInfo>({
     roomCode: null,
     setRoomCode: () => null,
     settingsEnabled: null,
+    botEnabled: null,
+    setBotEnabled: () => null,
     userInfo: null,
     setEditorActive: () => null,
 

--- a/src/context/SocketListeners.ts
+++ b/src/context/SocketListeners.ts
@@ -21,6 +21,7 @@ export const socketListeners = ({
     setJoinErrorMessage,
     setRoomCode,
     setSettingsEnabled,
+    setBotEnabled,
     setLineLength,
     setNRounds,
     setNPoems,
@@ -68,6 +69,10 @@ export const socketListeners = ({
 
     const receiveGameSettingsEnabled = (enabled: boolean) => {
         setSettingsEnabled(enabled);
+    };
+
+    const receiveBotEnabled = (enabled: boolean) => {
+        setBotEnabled(enabled);
     };
 
     // the React state lines is of type Array<Array<ILine["content"]>>
@@ -142,6 +147,7 @@ export const socketListeners = ({
     socket.on("stcRoomCode", receiveRoomCode);
     socket.on("stcGameSettingsInfo", receiveGameSettingsInfo);
     socket.on("stcGameSettingsEnabled", receiveGameSettingsEnabled);
+    socket.on("stcBotEnabled", receiveBotEnabled);
     socket.on("stcLineSpectator", receiveLineSpectator);
     socket.on("stcPanelSpectator", receivePanelSpectator);
     socket.on("stcPanelEditSpectator", receivePanelEditSpectator);
@@ -162,6 +168,7 @@ export const socketListeners = ({
         socket.off("stcRoomCode", receiveRoomCode);
         socket.off("stcGameSettingsInfo", receiveGameSettingsInfo);
         socket.off("stcGameSettingsEnabled", receiveGameSettingsEnabled);
+        socket.off("stcBotEnabled", receiveBotEnabled);
         socket.off("stcLineSpectator", receiveLineSpectator);
         socket.off("stcPanelSpectator", receivePanelSpectator);
         socket.off("stcPanelEditSpectator", receivePanelEditSpectator);

--- a/src/context/SocketRequestors.ts
+++ b/src/context/SocketRequestors.ts
@@ -79,6 +79,10 @@ export const emitRequestSettingsEnabled = () => {
     socket.emit("ctsRequestSettingsEnabled"); // initial populate
 };
 
+export const emitRequestBotEnabled = () => {
+    socket.emit("ctsRequestBotEnabled"); // initial populate
+};
+
 export const emitRequestGameSettingsInfo = () => {
     socket.emit("ctsRequestGameSettingsInfo");
 };

--- a/src/hooks/useInitializeGameSettings.ts
+++ b/src/hooks/useInitializeGameSettings.ts
@@ -1,10 +1,15 @@
-import { emitRequestGameSettingsInfo, emitRequestSettingsEnabled } from "context/SocketRequestors";
+import {
+    emitRequestBotEnabled,
+    emitRequestGameSettingsInfo,
+    emitRequestSettingsEnabled,
+} from "context/SocketRequestors";
 import { useState } from "react";
 
 export function useInitializeGameSettings() {
     const [rendered, setRendered] = useState(false);
     if (!rendered) {
         emitRequestSettingsEnabled();
+        emitRequestBotEnabled();
         emitRequestGameSettingsInfo();
         setRendered(true);
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -115,6 +115,7 @@ export interface ServerToClientEvents {
     stcUserTableInfo: (userTableInfo: IUserTableInfo) => void;
     stcGameSettingsInfo: (gameSettings: IGameSettingsInfo) => void;
     stcGameSettingsEnabled: (enabled: boolean) => void;
+    stcBotEnabled: (enabled: boolean) => void;
     stcNavigate: (targetRoute: string) => void;
     stcEditorActive: (isActive: boolean) => void;
     stcLastContribution: (isLast: boolean) => void;
@@ -142,6 +143,7 @@ export interface ClientToServerEvents {
     ctsRequestLastContributionStatus: () => void;
     ctsAlterGameSettings: (gameSettings: Partial<IGameSettingsInfo>) => void;
     ctsRequestSettingsEnabled: () => void;
+    ctsRequestBotEnabled: () => void;
     ctsStartGame: () => void;
     ctsAddPoemBot: () => void;
     ctsAddDrawingBot: () => void;
@@ -174,6 +176,8 @@ export interface ISocketInfoListeners {
     setRoomCode: (value: string | ((prevVar: string) => string)) => void;
     // React.useState<boolean>(false);
     setSettingsEnabled: (value: boolean | ((prevVar: boolean) => boolean)) => void;
+    // React.useState<boolean>(false);
+    setBotEnabled: (value: boolean | ((prevVar: boolean) => boolean)) => void;
     // React.useState<LineLength>(defaultGameSettings.lineLength);
     setLineLength: (value: LineLength | ((prevVar: LineLength) => LineLength)) => void;
     // React.useState<number>(defaultGameSettings.nRounds);
@@ -216,6 +220,8 @@ export interface ISocketInfo {
     roomCode: string | null;
     setRoomCode: (value: string | ((prevVar: string) => string)) => void;
     settingsEnabled: boolean | null;
+    botEnabled: boolean | null;
+    setBotEnabled: (value: boolean | ((prevVar: boolean) => boolean)) => void;
     userInfo: IUserTableInfo | null;
     setEditorActive: (value: boolean | ((prevVar: boolean) => boolean)) => void;
 


### PR DESCRIPTION
## Problem
The "Add Bot" gate lived in front-end code as a hardcoded `const SECRET_NAME = "SANANBYEKIM"` in `UserTable.tsx`. Because Vite inlines client code into the shipped bundle, that name was readable by anyone via DevTools — and it was committed to git history.

## Fix
Move the authorization decision entirely server-side, mirroring the existing `settingsEnabled` round-trip:
- Server (`Editor` base) exposes `isBotAuthorized()` (single source of truth, reads `AUTHORIZED_BOT_USER_NAME` from env) and answers a new `ctsRequestBotEnabled` → `stcBotEnabled(boolean)` query.
- Both `requestAddPoemBotToRoom` / `requestAddDrawingBotToRoom` now call `isBotAuthorized()` instead of duplicating the raw name check.
- Client requests `botEnabled` on init and gates the "Add Bot" button on that flag.
- Deleted the `SECRET_NAME` literal — the name no longer appears anywhere in front-end source or the bundle.

## Security boundary
The UI flag is cosmetic; the real enforcement is server-side in the add-bot handlers, so a crafted socket message still can't add a bot without the authorized name. The secret lives only in `server/.env` (gitignored).

## Verification
- Server: typecheck + lint clean, 115/115 tests
- Client: typecheck + lint clean, 107/107 tests
- `grep` confirms zero `SANANBYEKIM` / `SECRET_NAME` references in tracked source

🤖 Generated with [Claude Code](https://claude.com/claude-code)